### PR TITLE
feat: add profile import from JSON file

### DIFF
--- a/.github/profile-template.json
+++ b/.github/profile-template.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "Contoso-Commercial",
+    "tenantId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "clientId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "cloud": "Commercial",
+    "authMethod": "Interactive",
+    "clientSecret": ""
+  },
+  {
+    "name": "Contoso-GCC",
+    "tenantId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "clientId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "cloud": "GCC",
+    "authMethod": "Interactive",
+    "clientSecret": ""
+  },
+  {
+    "name": "Fabrikam-GCCHigh",
+    "tenantId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "clientId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "cloud": "GCCHigh",
+    "authMethod": "ClientSecret",
+    "clientSecret": "your-client-secret-value-here"
+  },
+  {
+    "name": "Fabrikam-DoD",
+    "tenantId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "clientId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "cloud": "DoD",
+    "authMethod": "ClientSecret",
+    "clientSecret": "your-client-secret-value-here"
+  }
+]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,41 @@ dotnet test --filter "FullyQualifiedName~ProfileServiceTests"
 dotnet run --project src/IntuneManager.Desktop
 ```
 
+### Profile Management
+
+Intune Commander stores connection details as **profiles** (tenant ID, client ID, cloud, auth method). Profiles are persisted locally in an encrypted file and never leave your machine.
+
+**Manually adding a profile:**
+1. Launch the app — you'll land on the login screen
+2. Fill in Tenant ID, Client ID, Cloud, and (optionally) Client Secret
+3. Click **Save Profile** to persist it for future sessions
+
+**Importing profiles from a JSON file:**
+1. Click **Import Profiles** on the login screen
+2. Select a `.json` file containing one or more profile definitions
+3. Profiles are merged in — duplicates (same Tenant ID + Client ID) are skipped automatically
+4. The imported profiles appear immediately in the **Saved Profiles** dropdown
+
+A ready-to-use template is available at [`.github/profile-template.json`](.github/profile-template.json). Download it, fill in your real Tenant IDs and Client IDs, and import it directly.
+
+**Supported JSON shapes:**
+
+```json
+// Array of profiles (recommended)
+[
+  {
+    "name": "Contoso-Prod",
+    "tenantId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "clientId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "cloud": "Commercial",
+    "authMethod": "Interactive"
+  }
+]
+```
+
+Valid `cloud` values: `Commercial`, `GCC`, `GCCHigh`, `DoD`
+Valid `authMethod` values: `Interactive` (browser popup), `ClientSecret` (include `"clientSecret"` field)
+
 ### App Registration Setup
 
 1. Go to **Azure Portal → Entra ID → App Registrations → New registration**

--- a/src/IntuneManager.Core/Services/ProfileImportHelper.cs
+++ b/src/IntuneManager.Core/Services/ProfileImportHelper.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using IntuneManager.Core.Models;
+
+namespace IntuneManager.Core.Services;
+
+/// <summary>
+/// Parses a JSON string into a list of <see cref="TenantProfile"/> objects.
+/// Supports three JSON shapes: an array of profiles, a single profile object,
+/// or a ProfileStore envelope ({ "profiles": [...] }).
+/// Invalid entries (missing required fields, unrecognised enum values) are skipped.
+/// </summary>
+public static class ProfileImportHelper
+{
+    private static readonly JsonSerializerOptions _options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter(allowIntegerValues: false) }
+    };
+
+    /// <summary>
+    /// Parses <paramref name="json"/> and returns all valid profiles found.
+    /// Throws <see cref="JsonException"/> if the JSON is syntactically invalid.
+    /// </summary>
+    public static List<TenantProfile> ParseProfiles(string json)
+    {
+        var node = JsonNode.Parse(json); // throws JsonException on bad syntax
+
+        if (node is JsonArray array)
+            return DeserializeArray(array);
+
+        if (node is JsonObject obj)
+        {
+            // ProfileStore envelope: { "profiles": [...] }
+            if (obj["profiles"] is JsonArray profilesArray)
+                return DeserializeArray(profilesArray);
+
+            // Single profile object
+            var single = TryDeserialize(node);
+            if (single is not null && IsValid(single))
+                return [single];
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Returns true when the profile has all required fields populated.
+    /// </summary>
+    public static bool IsValid(TenantProfile profile) =>
+        !string.IsNullOrWhiteSpace(profile.TenantId) &&
+        !string.IsNullOrWhiteSpace(profile.ClientId) &&
+        !string.IsNullOrWhiteSpace(profile.Name);
+
+    private static List<TenantProfile> DeserializeArray(JsonArray array) =>
+        array
+            .Select(n => n is null ? null : TryDeserialize(n))
+            .Where(p => p is not null && IsValid(p))
+            .Select(p => p!)
+            .ToList();
+
+    private static TenantProfile? TryDeserialize(JsonNode node)
+    {
+        try
+        {
+            return node.Deserialize<TenantProfile>(_options);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/IntuneManager.Desktop/Views/LoginView.axaml
+++ b/src/IntuneManager.Desktop/Views/LoginView.axaml
@@ -85,7 +85,7 @@
                          IsEnabled="{Binding !IsBusy}" />
             </StackPanel>
 
-            <!-- Save / Delete / New -->
+            <!-- Save / Delete / New / Import -->
             <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                 <Button Content="New"
                         Command="{Binding NewProfileCommand}"
@@ -96,6 +96,10 @@
                 <Button Content="Delete"
                         Command="{Binding DeleteProfileCommand}"
                         MinWidth="80" />
+                <Button Content="Import Profiles"
+                        Command="{Binding ImportProfilesCommand}"
+                        IsEnabled="{Binding !IsBusy}"
+                        MinWidth="120" />
             </StackPanel>
 
             <Button Content="Connect"

--- a/src/IntuneManager.Desktop/Views/LoginView.axaml.cs
+++ b/src/IntuneManager.Desktop/Views/LoginView.axaml.cs
@@ -1,11 +1,48 @@
+using System;
+using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+using IntuneManager.Desktop.ViewModels;
 
 namespace IntuneManager.Desktop.Views;
 
 public partial class LoginView : UserControl
 {
+    private LoginViewModel? _vm;
+
     public LoginView()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (_vm != null)
+            _vm.ImportProfilesRequested -= OnImportProfilesRequested;
+
+        _vm = DataContext as LoginViewModel;
+
+        if (_vm != null)
+            _vm.ImportProfilesRequested += OnImportProfilesRequested;
+    }
+
+    private async Task<string?> OnImportProfilesRequested()
+    {
+        var topLevel = TopLevel.GetTopLevel(this);
+        if (topLevel == null) return null;
+
+        var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Import Profiles from JSON",
+            AllowMultiple = false,
+            FileTypeFilter =
+            [
+                new FilePickerFileType("JSON files") { Patterns = ["*.json"] },
+                new FilePickerFileType("All files") { Patterns = ["*"] }
+            ]
+        });
+
+        return files.Count > 0 ? files[0].Path.LocalPath : null;
     }
 }

--- a/tests/IntuneManager.Core.Tests/Services/ProfileImportHelperTests.cs
+++ b/tests/IntuneManager.Core.Tests/Services/ProfileImportHelperTests.cs
@@ -1,0 +1,227 @@
+using IntuneManager.Core.Models;
+using IntuneManager.Core.Services;
+
+namespace IntuneManager.Core.Tests.Services;
+
+public class ProfileImportHelperTests
+{
+    // ── IsValid ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsValid_AllRequiredFieldsPresent_ReturnsTrue()
+    {
+        var profile = MakeProfile("P1");
+        Assert.True(ProfileImportHelper.IsValid(profile));
+    }
+
+    [Fact]
+    public void IsValid_MissingName_ReturnsFalse()
+    {
+        var profile = MakeProfile("");
+        Assert.False(ProfileImportHelper.IsValid(profile));
+    }
+
+    [Fact]
+    public void IsValid_MissingTenantId_ReturnsFalse()
+    {
+        var profile = MakeProfile("P1");
+        profile.TenantId = "";
+        Assert.False(ProfileImportHelper.IsValid(profile));
+    }
+
+    [Fact]
+    public void IsValid_MissingClientId_ReturnsFalse()
+    {
+        var profile = MakeProfile("P1");
+        profile.ClientId = "";
+        Assert.False(ProfileImportHelper.IsValid(profile));
+    }
+
+    [Fact]
+    public void IsValid_WhitespaceOnlyName_ReturnsFalse()
+    {
+        var profile = MakeProfile("   ");
+        Assert.False(ProfileImportHelper.IsValid(profile));
+    }
+
+    // ── ParseProfiles — array shape ────────────────────────────────────────
+
+    [Fact]
+    public void ParseProfiles_ArrayOfProfiles_ReturnsAll()
+    {
+        var json = """
+            [
+              { "name": "A", "tenantId": "00000000-0000-0000-0000-000000000001", "clientId": "00000000-0000-0000-0000-000000000002" },
+              { "name": "B", "tenantId": "00000000-0000-0000-0000-000000000003", "clientId": "00000000-0000-0000-0000-000000000004" }
+            ]
+            """;
+
+        var result = ProfileImportHelper.ParseProfiles(json);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("A", result[0].Name);
+        Assert.Equal("B", result[1].Name);
+    }
+
+    [Fact]
+    public void ParseProfiles_ArrayWithInvalidEntry_SkipsInvalid()
+    {
+        var json = """
+            [
+              { "name": "Good", "tenantId": "00000000-0000-0000-0000-000000000001", "clientId": "00000000-0000-0000-0000-000000000002" },
+              { "name": "", "tenantId": "00000000-0000-0000-0000-000000000003", "clientId": "00000000-0000-0000-0000-000000000004" }
+            ]
+            """;
+
+        var result = ProfileImportHelper.ParseProfiles(json);
+
+        Assert.Single(result);
+        Assert.Equal("Good", result[0].Name);
+    }
+
+    [Fact]
+    public void ParseProfiles_EmptyArray_ReturnsEmpty()
+    {
+        var result = ProfileImportHelper.ParseProfiles("[]");
+        Assert.Empty(result);
+    }
+
+    // ── ParseProfiles — single object shape ───────────────────────────────
+
+    [Fact]
+    public void ParseProfiles_SingleObject_ReturnsSingleProfile()
+    {
+        var json = """
+            { "name": "Solo", "tenantId": "00000000-0000-0000-0000-000000000001", "clientId": "00000000-0000-0000-0000-000000000002" }
+            """;
+
+        var result = ProfileImportHelper.ParseProfiles(json);
+
+        Assert.Single(result);
+        Assert.Equal("Solo", result[0].Name);
+    }
+
+    [Fact]
+    public void ParseProfiles_SingleObjectMissingRequiredField_ReturnsEmpty()
+    {
+        var json = """
+            { "tenantId": "00000000-0000-0000-0000-000000000001", "clientId": "00000000-0000-0000-0000-000000000002" }
+            """;
+
+        var result = ProfileImportHelper.ParseProfiles(json);
+
+        Assert.Empty(result);
+    }
+
+    // ── ParseProfiles — ProfileStore envelope shape ────────────────────────
+
+    [Fact]
+    public void ParseProfiles_ProfileStoreEnvelope_ReturnsProfiles()
+    {
+        var json = """
+            {
+              "profiles": [
+                { "name": "Env1", "tenantId": "00000000-0000-0000-0000-000000000001", "clientId": "00000000-0000-0000-0000-000000000002" },
+                { "name": "Env2", "tenantId": "00000000-0000-0000-0000-000000000003", "clientId": "00000000-0000-0000-0000-000000000004" }
+              ]
+            }
+            """;
+
+        var result = ProfileImportHelper.ParseProfiles(json);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Env1", result[0].Name);
+        Assert.Equal("Env2", result[1].Name);
+    }
+
+    [Fact]
+    public void ParseProfiles_ProfileStoreEnvelopeEmptyArray_ReturnsEmpty()
+    {
+        var result = ProfileImportHelper.ParseProfiles("""{ "profiles": [] }""");
+        Assert.Empty(result);
+    }
+
+    // ── ParseProfiles — field mapping ─────────────────────────────────────
+
+    [Fact]
+    public void ParseProfiles_CloudFieldMapped_ParsesCorrectly()
+    {
+        var json = """
+            [{ "name": "GCCTest", "tenantId": "00000000-0000-0000-0000-000000000001", "clientId": "00000000-0000-0000-0000-000000000002", "cloud": "GCCHigh" }]
+            """;
+
+        var result = ProfileImportHelper.ParseProfiles(json);
+
+        Assert.Single(result);
+        Assert.Equal(CloudEnvironment.GCCHigh, result[0].Cloud);
+    }
+
+    [Fact]
+    public void ParseProfiles_AuthMethodClientSecret_ParsesCorrectly()
+    {
+        var json = """
+            [{ "name": "SP", "tenantId": "00000000-0000-0000-0000-000000000001", "clientId": "00000000-0000-0000-0000-000000000002", "authMethod": "ClientSecret", "clientSecret": "abc123" }]
+            """;
+
+        var result = ProfileImportHelper.ParseProfiles(json);
+
+        Assert.Single(result);
+        Assert.Equal(AuthMethod.ClientSecret, result[0].AuthMethod);
+        Assert.Equal("abc123", result[0].ClientSecret);
+    }
+
+    [Fact]
+    public void ParseProfiles_CaseInsensitiveFieldNames_Parses()
+    {
+        var json = """
+            [{ "Name": "CaseTest", "TenantId": "00000000-0000-0000-0000-000000000001", "ClientId": "00000000-0000-0000-0000-000000000002" }]
+            """;
+
+        var result = ProfileImportHelper.ParseProfiles(json);
+
+        Assert.Single(result);
+        Assert.Equal("CaseTest", result[0].Name);
+    }
+
+    // ── ParseProfiles — error / edge cases ────────────────────────────────
+
+    [Fact]
+    public void ParseProfiles_InvalidJson_ThrowsJsonException()
+    {
+        // JsonReaderException is a subclass of JsonException
+        Assert.ThrowsAny<System.Text.Json.JsonException>(
+            () => ProfileImportHelper.ParseProfiles("not valid json {{{"));
+    }
+
+    [Fact]
+    public void ParseProfiles_NullValueInArray_SkipsNulls()
+    {
+        var json = """
+            [
+              { "name": "Real", "tenantId": "00000000-0000-0000-0000-000000000001", "clientId": "00000000-0000-0000-0000-000000000002" },
+              null
+            ]
+            """;
+
+        var result = ProfileImportHelper.ParseProfiles(json);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void ParseProfiles_UnrecognizedJsonShape_ReturnsEmpty()
+    {
+        // A JSON primitive (number) — not array or object
+        var result = ProfileImportHelper.ParseProfiles("42");
+        Assert.Empty(result);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private static TenantProfile MakeProfile(string name) => new()
+    {
+        Name = name,
+        TenantId = Guid.NewGuid().ToString(),
+        ClientId = Guid.NewGuid().ToString()
+    };
+}


### PR DESCRIPTION
## Summary
- Adds ability to import tenant profiles from a JSON file in the Login view
- Introduces `ProfileImportHelper` service to parse and validate profile JSON
- Adds a profile template file (`.github/profile-template.json`) and documents the import feature in the README

## Test plan
- [ ] Unit tests added in `ProfileImportHelperTests.cs` covering valid/invalid JSON, missing fields, and edge cases
- [ ] Manually verify the import button appears in the Login view and successfully imports a valid profile JSON
- [ ] Verify invalid/malformed JSON shows an appropriate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)