### PR TITLE
Phase 4: Cleanup — remove remaining active IntuneManager references

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ Intune Commander is a .NET 10 / Avalonia UI desktop app for managing Microsoft I
 ## Architecture
 - **Two-project solution**: `Intune.Commander.Core` (class library: auth, services, models) and `Intune.Commander.Desktop` (Avalonia UI app).
 - **MVVM with CommunityToolkit.Mvvm**: Use `[ObservableProperty]`, `[RelayCommand]`, and `partial` classes. ViewModels extend `ViewModelBase` which provides `IsBusy`/`ErrorMessage`.
-- **DI setup**: Services registered in `ServiceCollectionExtensions.AddIntuneManagerCore()`. Desktop-layer ViewModels registered in `App.axaml.cs`. Graph-dependent services (e.g., `ConfigurationProfileService`) are created manually after auth, not via DI.
+- **DI setup**: Services registered in `ServiceCollectionExtensions.AddIntuneCommanderCore()`. Desktop-layer ViewModels registered in `App.axaml.cs`. Graph-dependent services (e.g., `ConfigurationProfileService`) are created manually after auth, not via DI.
 - **ViewLocator pattern**: Avalonia resolves Views from ViewModels by naming convention (`FooViewModel` → `FooView`).
 
 ## Service-per-Type Pattern
@@ -60,7 +60,7 @@ Key rules:
 - **Graph SDK models used directly** — no wrapper DTOs. Types like `DeviceConfiguration`, `MobileApp` come from `Microsoft.Graph.Models`.
 - **Export format**: Subfolder-per-type (`DeviceConfigurations/`, `CompliancePolicies/`, `Applications/`) with `migration-table.json` for ID mappings. Must maintain read compatibility with the original PowerShell tool's JSON format.
 - **Export wrappers** for types with assignments: `CompliancePolicyExport`, `ApplicationExport` bundle the object + its assignments list.
-- **Profile storage**: Encrypted JSON at `%LOCALAPPDATA%\IntuneManager\profiles.json` using `Microsoft.AspNetCore.DataProtection`. Marker prefix `INTUNEMANAGER_ENC:` distinguishes encrypted from plain files.
+- **Profile storage**: Encrypted JSON at `%LOCALAPPDATA%\Intune.Commander\profiles.json` using `Microsoft.AspNetCore.DataProtection`. Marker prefix `INTUNEMANAGER_ENC:` distinguishes encrypted from plain files (marker preserved as compatibility constant).
 - **Multi-cloud**: `CloudEndpoints.GetEndpoints(cloud)` returns `(graphBaseUrl, authorityHost)` tuple. Separate app registrations per cloud.
 - **Computed columns**: DataGrid uses `DataGridColumnConfig` with `"Computed:"` prefix in `BindingPath` for values derived in code-behind (e.g., platform inferred from OData type).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,9 +73,9 @@ methods fail fast instead of falling back to interactive authentication.
 
 ### Profile Storage Location
 
-**Windows:** `%LOCALAPPDATA%\IntuneManager\profiles.json`  
-**Linux:** `~/.config/IntuneManager/profiles.json`  
-**macOS:** `~/Library/Application Support/IntuneManager/profiles.json`
+**Windows:** `%LOCALAPPDATA%\Intune.Commander\profiles.json`
+**Linux:** `~/.config/Intune.Commander/profiles.json`
+**macOS:** `~/Library/Application Support/Intune.Commander/profiles.json`
 
 ### Profile Schema
 ```json
@@ -103,7 +103,7 @@ methods fail fast instead of falling back to interactive authentication.
 **Rationale:**
 - Cross-platform encryption using a single consistent API
 - DPAPI-protected keys on Windows; file-system protected on macOS/Linux
-- Keys persist to `%LocalAppData%\IntuneManager\keys` directory
+- Keys persist to `%LocalAppData%\Intune.Commander\keys` directory
 
 **Implementation:**
 - Profile file encrypted via `Microsoft.AspNetCore.DataProtection`
@@ -391,7 +391,7 @@ ViewModels/
 
 ### Actual NuGet Packages (current)
 
-**IntuneManager.Core:**
+**Intune.Commander.Core:**
 ```xml
 <PackageReference Include="Azure.Identity" Version="1.17.1" />
 <PackageReference Include="LiteDB" Version="5.0.21" />
@@ -400,7 +400,7 @@ ViewModels/
 <PackageReference Include="Microsoft.Graph.Beta" Version="5.130.0-preview" />
 ```
 
-**IntuneManager.Desktop:**
+**Intune.Commander.Desktop:**
 ```xml
 <PackageReference Include="Avalonia" Version="11.3.12" />
 <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.12" />

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -444,7 +444,7 @@ Decisions can be revisited if new information emerges or requirements change.
 
 **Rationale:**
 - Cross-platform (Windows, macOS, Linux) — aligns with Avalonia's cross-platform story
-- Keys stored in `%LOCALAPPDATA%\IntuneManager\keys\`
+- Keys stored in `%LOCALAPPDATA%\Intune.Commander\keys\`
 - Automatic key rotation and management built-in
 - Transparent migration from plaintext (existing profiles auto-encrypt on next save)
 - Graceful handling of corrupted/migrated data (falls back to empty store)

--- a/docs/PRODUCT-RENAME-EFFORT.md
+++ b/docs/PRODUCT-RENAME-EFFORT.md
@@ -59,8 +59,8 @@ Per PR feedback, proceed with **Option B (full technical rename)**.
 - [x] Rename solution/projects/folders from `IntuneManager*` to `Intune.Commander*`. *(Phase 1 — PR #46)*
 - [x] Rename namespaces (`IntuneManager.*` → `Intune.Commander.*`) and fix all compile references. *(Phase 1 — PR #46)*
 - [x] Update CI/workflows/scripts/docs for renamed paths and project names. *(Phase 2 — PR #48)*
-- [x] Implement runtime migration to preserve existing local profile/cache readability. *(Phase 3 — this PR)*
-- [ ] Validate with `dotnet build` and `dotnet test --filter "Category!=Integration"`. *(Phase 4)*
+- [x] Implement runtime migration to preserve existing local profile/cache readability. *(Phase 3 — PR #50)*
+- [x] Cleanup remaining active `IntuneManager` references and final verification. *(Phase 4 — this PR)*
 
 ### Acceptance criteria for Option B
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -83,7 +83,7 @@ Each service follows these conventions:
 - **Phase B — Functional Completion:** Implement special helpers, normalization
 - **Phase C — Desktop Integration:** Add to `MainWindowViewModel`, UI wiring
 - **Phase D — Export/Import:** Extend `ExportService`/`ImportService`
-- **Phase E — Tests:** Add unit tests in `IntuneManager.Core.Tests`
+- **Phase E — Tests:** Add unit tests in `Intune.Commander.Core.Tests`
 
 ### Definition of Done (per service)
 

--- a/docs/issues/WAVE-5-CONDITIONAL-ACCESS-IDENTITY.md
+++ b/docs/issues/WAVE-5-CONDITIONAL-ACCESS-IDENTITY.md
@@ -176,6 +176,6 @@ Wave 5 focuses on implementing services for Conditional Access-adjacent identity
 - **Authentication Contexts** provide granular step-up authentication triggers for apps
 - **Terms of Use** agreements contain PDF files that need special handling
 - These resources are part of Azure AD/Entra ID, not Intune — ensure proper permissions are documented
-- Consider whether these services should be in a separate namespace (e.g., `IntuneManager.Core.Services.Identity`)
+- Consider whether these services should be in a separate namespace (e.g., `Intune.Commander.Core.Services.Identity`)
 - Built-in Authentication Strengths are read-only — handle appropriately in UI
 - Named Locations may be referenced by Conditional Access policies — consider dependency tracking

--- a/src/Intune.Commander.Core/Auth/InteractiveBrowserAuthProvider.cs
+++ b/src/Intune.Commander.Core/Auth/InteractiveBrowserAuthProvider.cs
@@ -16,7 +16,7 @@ public class InteractiveBrowserAuthProvider : IAuthenticationProvider
         // Allow unencrypted token cache on Linux where secure storage may not be available.
         var tokenCacheOptions = new TokenCachePersistenceOptions
         {
-            Name = $"IntuneManager-{profile.Id}",
+            Name = $"IntuneCommander-{profile.Id}",
             UnsafeAllowUnencryptedStorage = OperatingSystem.IsLinux()
         };
 

--- a/src/Intune.Commander.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Intune.Commander.Core/Extensions/ServiceCollectionExtensions.cs
@@ -7,15 +7,14 @@ namespace Intune.Commander.Core.Extensions;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddIntuneManagerCore(this IServiceCollection services)
+    public static IServiceCollection AddIntuneCommanderCore(this IServiceCollection services)
     {
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
         // DataProtection — keys stored in the user's local app data folder.
         // NOTE: SetApplicationName("IntuneManager") is intentionally preserved as a
-        // read-only compatibility constant (Phase 3). Changing it would make all
-        // existing encrypted profile data permanently unreadable. It will be
-        // re-evaluated in Phase 4 once all legacy data has been migrated.
+        // read-only compatibility constant. Changing it would make all existing
+        // DataProtection-encrypted profile data permanently unreadable.
         var legacyKeysPath = Path.Combine(appData, "IntuneManager", "keys");
         var keysPath = Path.Combine(appData, "Intune.Commander", "keys");
 

--- a/src/Intune.Commander.Desktop/App.axaml.cs
+++ b/src/Intune.Commander.Desktop/App.axaml.cs
@@ -37,7 +37,7 @@ public partial class App : Application
             DisableAvaloniaDataAnnotationValidation();
 
             var services = new ServiceCollection();
-            services.AddIntuneManagerCore();
+            services.AddIntuneCommanderCore();
             services.AddTransient<MainWindowViewModel>();
             Services = services.BuildServiceProvider();
 

--- a/tests/Intune.Commander.Core.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/tests/Intune.Commander.Core.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -13,7 +13,7 @@ public class ServiceCollectionExtensionsTests : IDisposable
     public ServiceCollectionExtensionsTests()
     {
         var services = new ServiceCollection();
-        services.AddIntuneManagerCore();
+        services.AddIntuneCommanderCore();
         _provider = services.BuildServiceProvider();
     }
 
@@ -24,10 +24,10 @@ public class ServiceCollectionExtensionsTests : IDisposable
     }
 
     [Fact]
-    public void AddIntuneManagerCore_Returns_Same_ServiceCollection()
+    public void AddIntuneCommanderCore_Returns_Same_ServiceCollection()
     {
         var services = new ServiceCollection();
-        var result = services.AddIntuneManagerCore();
+        var result = services.AddIntuneCommanderCore();
         Assert.Same(services, result);
     }
 
@@ -99,7 +99,7 @@ public class ServiceCollectionExtensionsTests : IDisposable
     [Fact]
     public void All_Expected_Services_Are_Registered()
     {
-        // Verify every service registered by AddIntuneManagerCore is resolvable
+        // Verify every service registered by AddIntuneCommanderCore is resolvable
         Assert.NotNull(_provider.GetService<IDataProtectionProvider>());
         Assert.NotNull(_provider.GetService<IProfileEncryptionService>());
         Assert.NotNull(_provider.GetService<IAuthenticationProvider>());

--- a/tests/Intune.Commander.Core.Tests/Services/CacheSerializationTests.cs
+++ b/tests/Intune.Commander.Core.Tests/Services/CacheSerializationTests.cs
@@ -17,7 +17,7 @@ public class CacheSerializationTests : IDisposable
 
     public CacheSerializationTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"IntuneManager_CacheSerTests_{Guid.NewGuid():N}");
+        _tempDir = Path.Combine(Path.GetTempPath(), $"IntuneCommander_CacheSerTests_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
 
         var services = new ServiceCollection();

--- a/tests/Intune.Commander.Core.Tests/Services/CacheServiceTests.cs
+++ b/tests/Intune.Commander.Core.Tests/Services/CacheServiceTests.cs
@@ -12,7 +12,7 @@ public class CacheServiceTests : IDisposable
 
     public CacheServiceTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"IntuneManager_CacheTests_{Guid.NewGuid():N}");
+        _tempDir = Path.Combine(Path.GetTempPath(), $"IntuneCommander_CacheTests_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
 
         var services = new ServiceCollection();

--- a/tests/Intune.Commander.Core.Tests/Services/ProfileEncryptionServiceTests.cs
+++ b/tests/Intune.Commander.Core.Tests/Services/ProfileEncryptionServiceTests.cs
@@ -13,14 +13,14 @@ public class ProfileEncryptionServiceTests : IDisposable
 
     public ProfileEncryptionServiceTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"intunemanager-enc-test-{Guid.NewGuid()}");
+        _tempDir = Path.Combine(Path.GetTempPath(), $"intunecommander-enc-test-{Guid.NewGuid()}");
         _keysDir = Path.Combine(_tempDir, "keys");
         Directory.CreateDirectory(_keysDir);
 
         // Build a real DataProtection provider for integration tests
         var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
         services.AddDataProtection()
-            .SetApplicationName("IntuneManager-Tests")
+            .SetApplicationName("IntuneCommander-Tests")
             .PersistKeysToFileSystem(new DirectoryInfo(_keysDir));
 
         var sp = services.BuildServiceProvider();
@@ -68,7 +68,7 @@ public class ProfileEncryptionServiceTests : IDisposable
         // The service must fall back to "IntuneManager.Profiles.v1" and decrypt it successfully.
         var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
         services.AddDataProtection()
-            .SetApplicationName("IntuneManager-Tests")
+            .SetApplicationName("IntuneCommander-Tests")
             .PersistKeysToFileSystem(new DirectoryInfo(_keysDir));
         using var sp = services.BuildServiceProvider();
         var provider = sp.GetRequiredService<Microsoft.AspNetCore.DataProtection.IDataProtectionProvider>();
@@ -94,14 +94,14 @@ public class EncryptedProfileServiceTests : IDisposable
 
     public EncryptedProfileServiceTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"intunemanager-encprofile-test-{Guid.NewGuid()}");
+        _tempDir = Path.Combine(Path.GetTempPath(), $"intunecommander-encprofile-test-{Guid.NewGuid()}");
         _profilePath = Path.Combine(_tempDir, "profiles.json");
         var keysDir = Path.Combine(_tempDir, "keys");
         Directory.CreateDirectory(keysDir);
 
         var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
         services.AddDataProtection()
-            .SetApplicationName("IntuneManager-Tests")
+            .SetApplicationName("IntuneCommander-Tests")
             .PersistKeysToFileSystem(new DirectoryInfo(keysDir));
 
         var sp = services.BuildServiceProvider();


### PR DESCRIPTION
Closes #45

## Summary

Final phase of Option B rename. Removes all remaining **active** `IntuneManager` identifiers from source code and docs, leaving only the explicitly-documented backward-compatibility constants intact.

## Changes

### Source code
| File | Change |
|------|--------|
| `InteractiveBrowserAuthProvider.cs` | Token cache name `IntuneManager-{id}` → `IntuneCommander-{id}` |
| `ServiceCollectionExtensions.cs` | `AddIntuneManagerCore` → `AddIntuneCommanderCore`; cleaned up Phase 3 comment |
| `App.axaml.cs` | Call site updated to `AddIntuneCommanderCore()` |

### Tests
| File | Change |
|------|--------|
| `ServiceCollectionExtensionsTests.cs` | All method name refs renamed |
| `CacheServiceTests.cs` | Temp dir prefix renamed |
| `CacheSerializationTests.cs` | Temp dir prefix renamed |
| `ProfileEncryptionServiceTests.cs` | App isolation name renamed (`"IntuneManager.Profiles.v1"` string preserved — it is the value under test) |

### Docs
- `CLAUDE.md` — method names, storage paths, stale Phase 3 "future" notes replaced with current facts
- `copilot-instructions.md` — DI method name + profile path
- `docs/ARCHITECTURE.md` — paths and project headings
- `docs/DECISIONS.md` — DataProtection keys path
- `docs/issues/README.md` — test project name
- `docs/issues/WAVE-5-CONDITIONAL-ACCESS-IDENTITY.md` — namespace example
- `docs/PRODUCT-RENAME-EFFORT.md` — Phase 4 `[x]`

## Remaining IntuneManager strings (all documented compatibility constants)

| Constant | Location | Reason |
|----------|----------|--------|
| `SetApplicationName("IntuneManager")` | `ServiceCollectionExtensions` | Changing this makes all existing DataProtection-encrypted profiles unreadable |
| `LegacyPurpose = "IntuneManager.Profiles.v1"` | `ProfileEncryptionService` | Fallback decryptor for profiles written before Phase 1 |
| `GetLegacyProfilePath()` returning `IntuneManager` path | `ProfileService` | Phase 3 migration source detector |
| `legacyKeysPath IntuneManager/keys` | `ServiceCollectionExtensions` | Phase 3 key migration source |

## Validation

```
dotnet build   → 0 errors, 0 warnings
dotnet test --filter "Category!=Integration"  → 716 passed, 0 failed
```

## Note on token cache rename

`InteractiveBrowserAuthProvider` uses `IntuneCommander-{profileId}` as the MSAL token cache name. Existing users will be prompted to re-authenticate once after upgrading (their cached token under the old name won't be found). This is a one-time UX cost with no data loss.