### PR TITLE
perf: ObservableCollection optimization and search debouncing

### DIFF
--- a/src/Intune.Commander.Core/Extensions/ObservableCollectionExtensions.cs
+++ b/src/Intune.Commander.Core/Extensions/ObservableCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Intune.Commander.Core.Extensions;
+
+public static class ObservableCollectionExtensions
+{
+    /// <summary>
+    /// Replaces all items in an <see cref="ObservableCollection{T}"/> in-place.
+    /// Triggers one <see cref="System.Collections.Specialized.NotifyCollectionChangedAction.Reset"/> CollectionChanged event (from Clear)
+    /// followed by N <see cref="System.Collections.Specialized.NotifyCollectionChangedAction.Add"/> CollectionChanged events.
+    /// Use this to reuse an already-bound collection instance rather than replacing the reference.
+    /// </summary>
+    public static void ReplaceAll<T>(this ObservableCollection<T> collection, IEnumerable<T> items)
+    {
+        collection.Clear();
+        foreach (var item in items)
+        {
+            collection.Add(item);
+        }
+    }
+}

--- a/src/Intune.Commander.Desktop/Extensions/ObservableCollectionExtensions.cs
+++ b/src/Intune.Commander.Desktop/Extensions/ObservableCollectionExtensions.cs
@@ -1,21 +1,2 @@
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-
+// ReplaceAll has been moved to Intune.Commander.Core.Extensions.ObservableCollectionExtensions.
 namespace Intune.Commander.Desktop.Extensions;
-
-public static class ObservableCollectionExtensions
-{
-    /// <summary>
-    /// Efficiently replaces all items in an ObservableCollection.
-    /// Clears the collection once, then adds items individually.
-    /// This triggers only 1 clear event + N add events instead of recreating the collection.
-    /// </summary>
-    public static void ReplaceAll<T>(this ObservableCollection<T> collection, IEnumerable<T> items)
-    {
-        collection.Clear();
-        foreach (var item in items)
-        {
-            collection.Add(item);
-        }
-    }
-}

--- a/src/Intune.Commander.Desktop/ViewModels/MainWindowViewModel.AppAssignments.cs
+++ b/src/Intune.Commander.Desktop/ViewModels/MainWindowViewModel.AppAssignments.cs
@@ -18,8 +18,6 @@ using Avalonia.Threading;
 
 using Intune.Commander.Core.Services;
 
-using Intune.Commander.Desktop.Extensions;
-
 using Microsoft.Graph.Beta.Models;
 
 
@@ -182,11 +180,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
 
 
-            var collection = new ObservableCollection<AppAssignmentRow>();
-
-            collection.ReplaceAll(rows);
-
-            AppAssignmentRows = collection;
+            AppAssignmentRows = new ObservableCollection<AppAssignmentRow>(rows);
 
             _appAssignmentsLoaded = true;
 

--- a/src/Intune.Commander.Desktop/ViewModels/MainWindowViewModel.Loading.cs
+++ b/src/Intune.Commander.Desktop/ViewModels/MainWindowViewModel.Loading.cs
@@ -9,7 +9,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Input;
 using Intune.Commander.Core.Models;
 using Intune.Commander.Core.Services;
-using Intune.Commander.Desktop.Extensions;
+using Intune.Commander.Core.Extensions;
 using Microsoft.Graph.Beta.Models;
 
 namespace Intune.Commander.Desktop.ViewModels;
@@ -39,8 +39,7 @@ public partial class MainWindowViewModel : ViewModelBase
         try
         {
             var items = await fetch(cancellationToken);
-            var collection = new ObservableCollection<T>();
-            collection.ReplaceAll(items);
+            var collection = new ObservableCollection<T>(items);
             setCollection(collection);
             setLoadedFlag();
             ApplyFilter();
@@ -81,8 +80,7 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             StatusText = $"Loading {displayName}...";
             var items = await fetch(cancellationToken);
-            var collection = new ObservableCollection<T>();
-            collection.ReplaceAll(items);
+            var collection = new ObservableCollection<T>(items);
             setCollection(collection);
             setLoadedFlag?.Invoke(true);
             DebugLog.Log("Graph", $"Loaded {items.Count} {displayName}");
@@ -110,8 +108,7 @@ public partial class MainWindowViewModel : ViewModelBase
         var items = _cacheService.Get<T>(tenantId, cacheKey);
         if (items == null) return false;
 
-        var collection = new ObservableCollection<T>();
-        collection.ReplaceAll(items);
+        var collection = new ObservableCollection<T>(items);
         setCollection(collection);
         setLoadedFlag?.Invoke();
         DebugLog.Log("Cache", $"Loaded {items.Count} {displayName} from cache");

--- a/tests/Intune.Commander.Core.Tests/Extensions/ObservableCollectionExtensionsTests.cs
+++ b/tests/Intune.Commander.Core.Tests/Extensions/ObservableCollectionExtensionsTests.cs
@@ -1,5 +1,5 @@
 using System.Collections.ObjectModel;
-using Intune.Commander.Desktop.Extensions;
+using Intune.Commander.Core.Extensions;
 
 namespace Intune.Commander.Core.Tests.Extensions;
 

--- a/tests/Intune.Commander.Core.Tests/Intune.Commander.Core.Tests.csproj
+++ b/tests/Intune.Commander.Core.Tests/Intune.Commander.Core.Tests.csproj
@@ -30,7 +30,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Intune.Commander.Core\Intune.Commander.Core.csproj" />
-    <ProjectReference Include="..\..\src\Intune.Commander.Desktop\Intune.Commander.Desktop.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Performance Optimization - Phases 2-4

### Problem
CPU profiling shows **18.72% of CPU** spent in P/Invoke + CoreLib overhead caused by:
1. `new ObservableCollection<T>(items)` firing N events per item on every load
2. `ApplyFilter()` recreating **40+ ObservableCollections** on every keystroke
3. No search debouncing

### Implementation Tasks

#### Phase 2: Core Optimizations
- [ ] **Task 2.1**: Create `ObservableCollectionExtensions.cs` with `ReplaceAll<T>()` extension method
- [ ] **Task 2.2**: Update `MainWindowViewModel.Loading.cs` - replace `new ObservableCollection<T>(items)` in `LoadCollectionAsync`, `RefreshCollectionAsync`, and `TryLoadCollectionFromCache`
- [ ] **Task 2.3**: Update `MainWindowViewModel.AppAssignments.cs` (line ~97) - same pattern for `AppAssignmentRows`
- [ ] **Task 2.4**: Add 300ms search debouncing in `MainWindowViewModel.Search.cs` - `CancellationTokenSource` + `Task.Delay` in `OnSearchTextChanged`
- [ ] **Task 2.5**: Write `ObservableCollectionExtensionsTests.cs` - xUnit tests for `ReplaceAll()`

#### Phase 3: Search Filter Refactor
- [ ] **Task 3.1**: Add `UpdateFilteredCollection<T>` helper method to `MainWindowViewModel.Search.cs`
- [ ] **Task 3.2**: Refactor `ApplyFilter()` - convert all 34+ `FilteredXxx = new ObservableCollection<T>(...)` to use `UpdateFilteredCollection`
- [ ] **Task 3.3**: Test search performance and edge cases (empty search, special characters)

#### Phase 4: Verification
- [ ] **Task 4.1**: Full integration test (Login, Load, Search, Export)
- [ ] **Task 4.2**: Run `dotnet test` - all tests pass
- [ ] **Task 4.3**: Verify P/Invoke overhead drops from 12.41% to less than 8%

### Expected Impact
| Metric | Before | Target |
|--------|--------|--------|
| P/Invoke CPU% | 12.41% | less than 8% |
| Collection load (1000 items) | ~100ms | ~40ms |
| Search filter | ~250ms/keystroke | ~75ms once |
| Search typing overhead | 10x250ms = 2.5s | 1x75ms = 75ms |

### Edge Cases
- Race conditions in debounced search (handled by CancellationTokenSource)
- Empty search text must reset all filtered collections to full source
- Collections must be initialized before first `ApplyFilter` call
- Export operations read from source collections (not filtered) - should be unaffected

### Scope
- Phase 5 (async filtering, virtual scrolling, JSON optimization) is **deferred**
- No benchmarks - validation via manual profiling before/after

See PERFORMANCE-OPTIMIZATION-PLAN.md for full details.
