### PR TITLE
fix: expand ApplicationService $select for detail panel fields

### DIFF
--- a/src/Intune.Commander.Core/Services/ApplicationService.cs
+++ b/src/Intune.Commander.Core/Services/ApplicationService.cs
@@ -21,10 +21,49 @@ public class ApplicationService : IApplicationService
         var response = await _graphClient.DeviceAppManagement.MobileApps
             .GetAsync(req =>
             {
-                req.QueryParameters.Top = 200;
+                req.QueryParameters.Top = 999;
                 req.QueryParameters.Select = [
-                    "id", "displayName", "publisher", "description",
-                    "createdDateTime", "lastModifiedDateTime", "publishingState"
+                    // Base MobileApp properties used in the detail panel and column grid
+                    "id", "displayName", "description", "publisher",
+                    "owner", "developer", "notes",
+                    "isFeatured", "isAssigned",
+                    "informationUrl", "privacyInformationUrl",
+                    "createdDateTime", "lastModifiedDateTime", "publishingState",
+                    "roleScopeTagIds", "categories",
+                    "supersededAppCount", "supersedingAppCount", "dependentAppCount",
+                    // Subtype: Win32LobApp
+                    "microsoft.graph.win32LobApp/installCommandLine",
+                    "microsoft.graph.win32LobApp/uninstallCommandLine",
+                    "microsoft.graph.win32LobApp/installExperience",
+                    "microsoft.graph.win32LobApp/msiInformation",
+                    "microsoft.graph.win32LobApp/size",
+                    "microsoft.graph.win32LobApp/minimumSupportedWindowsRelease",
+                    // Subtype: IosLobApp
+                    "microsoft.graph.iosLobApp/bundleId",
+                    "microsoft.graph.iosLobApp/versionNumber",
+                    "microsoft.graph.iosLobApp/minimumSupportedOperatingSystem",
+                    "microsoft.graph.iosLobApp/size",
+                    // Subtype: IosStoreApp
+                    "microsoft.graph.iosStoreApp/bundleId",
+                    "microsoft.graph.iosStoreApp/appStoreUrl",
+                    "microsoft.graph.iosStoreApp/minimumSupportedOperatingSystem",
+                    // Subtype: IosVppApp
+                    "microsoft.graph.iosVppApp/bundleId",
+                    // Subtype: MacOSLobApp
+                    "microsoft.graph.macOSLobApp/bundleId",
+                    "microsoft.graph.macOSLobApp/versionNumber",
+                    "microsoft.graph.macOSLobApp/minimumSupportedOperatingSystem",
+                    "microsoft.graph.macOSLobApp/size",
+                    // Subtype: MacOSDmgApp
+                    "microsoft.graph.macOSDmgApp/primaryBundleId",
+                    "microsoft.graph.macOSDmgApp/primaryBundleVersion",
+                    "microsoft.graph.macOSDmgApp/minimumSupportedOperatingSystem",
+                    // Subtype: AndroidStoreApp
+                    "microsoft.graph.androidStoreApp/packageId",
+                    "microsoft.graph.androidStoreApp/appStoreUrl",
+                    "microsoft.graph.androidStoreApp/minimumSupportedOperatingSystem",
+                    // Subtype: WebApp
+                    "microsoft.graph.webApp/appUrl",
                 ];
             }, cancellationToken);
 


### PR DESCRIPTION
## Summary
- Expands `$select` in `ListApplicationsAsync` to include all fields needed by the detail panel and column grid
- Adds `owner`, `developer`, `notes`, `isFeatured`, `isAssigned`, `informationUrl`, `privacyInformationUrl`, `categories`, `roleScopeTagIds`, and superseded/dependent counts
- Adds OData type-cast `$select` entries for Win32LobApp, iOS, macOS, Android, and WebApp subtypes (install commands, bundle IDs, version info, etc.)
- Raises `$top` from 200 to 999 (project convention)

Supersedes #154 (applied the `$select` fix, skipped the stale `global.json` SDK downgrade).

Also closed #144 and #149 — those are sub-PRs of #142 (Wave 13) targeting files that don't exist on main yet.

## Test plan
- [x] `dotnet build` — no errors
- [x] `dotnet test` — 1082 passed (2 unrelated file-lock failures on cache.db)
- [ ] Manual: verify detail panel fields populate for Win32/iOS/macOS/Android apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)