### PR TITLE
Set environment for update-definitions job

### DIFF
--- a/.github/workflows/update-settings-catalog.yml
+++ b/.github/workflows/update-settings-catalog.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   update-definitions:
     runs-on: windows-latest
+    environment: integration-test
     permissions:
       contents: write
 


### PR DESCRIPTION
Add the environment "integration-test" to the update-definitions job in the GitHub Actions workflow. This scopes the job to the integration-test environment, enabling environment-specific secrets, protection rules, or required reviewers where configured.