### PR TITLE
feat: Settings Catalog UI mockup for React web shell

### DIFF
--- a/webview-first-slice-mockups.html
+++ b/webview-first-slice-mockups.html
@@ -1,0 +1,3530 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Intune Commander Webview Mockups</title>
+  <style>
+    :root {
+      --bg: #0b1020;
+      --bg-soft: #111827;
+      --surface: #101828;
+      --surface-alt: #182230;
+      --border: #243244;
+      --border-strong: #344054;
+      --text: #f8fafc;
+      --text-secondary: #e2e8f0;
+      --text-tertiary: #94a3b8;
+      --text-muted: #64748b;
+      --brand: #a78bfa;
+      --brand-soft: rgba(167, 139, 250, 0.14);
+      --brand-border: rgba(167, 139, 250, 0.34);
+      --success: #4ade80;
+      --success-soft: rgba(74, 222, 128, 0.14);
+      --warning: #fbbf24;
+      --warning-soft: rgba(251, 191, 36, 0.14);
+      --error: #fb7185;
+      --error-soft: rgba(251, 113, 133, 0.14);
+      --blue: #60a5fa;
+      --blue-soft: rgba(96, 165, 250, 0.14);
+      --shadow-sm: 0 1px 2px rgba(2, 6, 23, 0.35);
+      --shadow-md: 0 18px 40px rgba(2, 6, 23, 0.45);
+      --radius-lg: 16px;
+      --radius-md: 12px;
+      --radius-sm: 10px;
+    }
+
+    * { box-sizing: border-box; }
+
+    html, body {
+      margin: 0;
+      min-height: 100%;
+      background: linear-gradient(180deg, #0b1020 0%, #111827 100%);
+      color: var(--text);
+      font: 14px/1.45 Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    body { padding: 24px; }
+
+    button, input { font: inherit; }
+
+    .page {
+      max-width: 1720px;
+      margin: 0 auto;
+      display: grid;
+      gap: 18px;
+    }
+
+    .summary-banner {
+      display: grid;
+      grid-template-columns: 1.3fr 0.9fr;
+      gap: 20px;
+      padding: 24px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      box-shadow: var(--shadow-sm);
+    }
+
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--brand);
+      font-size: 12px;
+      font-weight: 600;
+      margin-bottom: 10px;
+    }
+
+    .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 999px;
+      background: var(--brand);
+    }
+
+    h1 {
+      margin: 0 0 8px;
+      font-size: 30px;
+      line-height: 1.1;
+      letter-spacing: -0.02em;
+    }
+
+    .summary-banner p {
+      margin: 0;
+      color: var(--text-tertiary);
+      max-width: 860px;
+      font-size: 16px;
+    }
+
+    .banner-notes {
+      display: grid;
+      gap: 12px;
+    }
+
+    .mini-note {
+      padding: 14px 16px;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--surface-alt);
+    }
+
+    .mini-note strong {
+      display: block;
+      margin-bottom: 4px;
+      font-size: 13px;
+    }
+
+    .mini-note span {
+      color: var(--text-tertiary);
+      display: block;
+    }
+
+    .switcher {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .switcher button {
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text-secondary);
+      border-radius: 999px;
+      padding: 10px 14px;
+      cursor: pointer;
+      box-shadow: var(--shadow-sm);
+    }
+
+    .switcher button.active {
+      background: var(--brand-soft);
+      border-color: var(--brand-border);
+      color: var(--brand);
+      font-weight: 600;
+    }
+
+    .app-shell {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 24px;
+      overflow: hidden;
+      box-shadow: var(--shadow-md);
+    }
+
+    .shell-topbar {
+      display: grid;
+      gap: 0;
+      border-bottom: 1px solid var(--border);
+      background: rgba(11, 18, 32, 0.84);
+      backdrop-filter: blur(10px);
+    }
+
+    .shell-header-primary,
+    .shell-header-secondary {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 14px;
+      padding: 12px 18px;
+    }
+
+    .shell-header-primary {
+      border-bottom: 1px solid var(--border);
+    }
+
+    .shell-header-secondary {
+      background: rgba(11, 18, 32, 0.48);
+    }
+
+    .topbar-left,
+    .topbar-right,
+    .toolbar-left,
+    .toolbar-right {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .primary-nav,
+    .secondary-nav {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+
+    .nav-tier-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 7px 10px;
+      border-radius: 9px;
+      border: 1px solid transparent;
+      color: var(--text-tertiary);
+      background: transparent;
+      font-size: 12px;
+      font-weight: 500;
+    }
+
+    .nav-tier-link.active {
+      background: rgba(127, 86, 217, 0.12);
+      border-color: rgba(127, 86, 217, 0.16);
+      color: #d6bbfb;
+    }
+
+    .nav-tier-link.secondary {
+      padding: 6px 9px;
+      font-size: 12px;
+    }
+
+    .header-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 9px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: rgba(15, 23, 42, 0.42);
+      color: var(--text-secondary);
+      font-size: 12px;
+    }
+
+    .product-mark {
+      width: 30px;
+      height: 30px;
+      border-radius: 9px;
+      background: linear-gradient(135deg, #a78bfa 0%, #7c3aed 100%);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
+    }
+
+    .product-copy strong {
+      display: block;
+      font-size: 14px;
+    }
+
+    .product-copy span {
+      display: block;
+      color: var(--text-tertiary);
+      font-size: 12px;
+    }
+
+    .search {
+      min-width: 240px;
+      padding: 9px 11px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: rgba(15, 23, 42, 0.56);
+      color: var(--text-secondary);
+    }
+
+    .shell-topbar .ghost-btn,
+    .shell-topbar .secondary-btn,
+    .shell-topbar .primary-btn {
+      padding: 8px 12px;
+      box-shadow: none;
+    }
+
+    .shell-topbar .ghost-btn {
+      background: transparent;
+      border-color: transparent;
+    }
+
+    .shell-topbar .secondary-btn {
+      background: rgba(127, 86, 217, 0.1);
+      border-color: rgba(127, 86, 217, 0.14);
+      color: #d6bbfb;
+    }
+
+    .ghost-btn,
+    .primary-btn,
+    .secondary-btn {
+      border-radius: 10px;
+      padding: 10px 14px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text-secondary);
+      cursor: pointer;
+      box-shadow: var(--shadow-sm);
+    }
+
+    .primary-btn {
+      background: var(--brand);
+      color: white;
+      border-color: var(--brand);
+    }
+
+    .secondary-btn {
+      background: var(--brand-soft);
+      border-color: var(--brand-border);
+      color: var(--brand);
+    }
+
+    .main-grid {
+      display: grid;
+      grid-template-columns: 320px 1fr;
+      min-height: 960px;
+    }
+
+    .sidebar {
+      border-right: 1px solid var(--border);
+      background: #0f172a;
+    }
+
+    .sidebar-panel {
+      padding: 16px 14px;
+      display: grid;
+      align-content: start;
+      gap: 12px;
+    }
+
+    .sidebar-panel-header {
+      display: grid;
+      gap: 3px;
+      padding: 0 6px;
+    }
+
+    .sidebar-panel-header strong {
+      font-size: 14px;
+    }
+
+    .sidebar-panel-header span {
+      color: var(--text-tertiary);
+      font-size: 12px;
+    }
+
+    .sidebar-menu-search {
+      position: relative;
+      padding: 0 6px 4px;
+    }
+
+    .sidebar-menu-search svg {
+      position: absolute;
+      left: 18px;
+      top: 50%;
+      width: 14px;
+      height: 14px;
+      color: var(--text-muted);
+      transform: translateY(-42%);
+      pointer-events: none;
+    }
+
+    .sidebar-menu-search input {
+      width: 100%;
+      padding: 10px 12px 10px 34px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: rgba(15, 23, 42, 0.58);
+      color: var(--text-secondary);
+      font-size: 13px;
+    }
+
+    .nav-group {
+      display: grid;
+      gap: 4px;
+    }
+
+    .nav-label {
+      color: var(--text-muted);
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      padding: 0 6px;
+    }
+
+    .nav-item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 10px 10px;
+      border-radius: 10px;
+      color: var(--text-secondary);
+      border: 1px solid transparent;
+      background: transparent;
+    }
+
+    .nav-item.active {
+      background: rgba(127, 86, 217, 0.1);
+      color: #e2e8f0;
+      border-color: rgba(127, 86, 217, 0.12);
+      font-weight: 600;
+    }
+
+    .nav-item-main {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-width: 0;
+      flex: 1;
+    }
+
+    .nav-item-icon {
+      width: 16px;
+      height: 16px;
+      color: currentColor;
+      flex: 0 0 auto;
+    }
+
+    .nav-item-label {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .nav-item small {
+      color: var(--text-muted);
+      font-size: 11px;
+      padding: 2px 7px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(148, 163, 184, 0.12);
+    }
+
+    .nav-item.active small {
+      color: #d6bbfb;
+      border-color: rgba(127, 86, 217, 0.14);
+      background: rgba(127, 86, 217, 0.08);
+    }
+
+    .workspace {
+      display: none;
+      padding: 20px;
+      gap: 16px;
+      background: #0b1220;
+    }
+
+    .workspace.active {
+      display: grid;
+    }
+
+    .section-toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 16px;
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      background: var(--surface);
+    }
+
+    .section-heading {
+      display: grid;
+      gap: 6px;
+    }
+
+    .section-breadcrumb {
+      margin: 0 0 6px;
+    }
+
+    .breadcrumb {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+      position: relative;
+      padding: 8px 2px 8px 4px;
+      margin: 0;
+      list-style: none;
+      color: var(--text-muted);
+      font-size: 12px;
+      font-weight: 600;
+    }
+
+    .breadcrumb::before,
+    .breadcrumb::after {
+      content: "";
+      position: absolute;
+      inset-inline: 0;
+      height: 1px;
+      background: rgba(148, 163, 184, 0.18);
+      pointer-events: none;
+    }
+
+    .breadcrumb::before { top: 0; }
+
+    .breadcrumb::after { bottom: 0; }
+
+    .breadcrumb-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      min-width: 0;
+    }
+
+    .breadcrumb-link,
+    .breadcrumb-current {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      min-width: 0;
+      padding: 4px 8px;
+      border-radius: 8px;
+      white-space: nowrap;
+    }
+
+    .breadcrumb-link {
+      color: var(--text-muted);
+      background: transparent;
+      border: 1px solid transparent;
+    }
+
+    .breadcrumb-link.icon-only {
+      padding-inline: 6px;
+    }
+
+    .breadcrumb-link:hover {
+      color: var(--text-secondary);
+      background: rgba(255, 255, 255, 0.03);
+    }
+
+    .breadcrumb-current {
+      color: #d6bbfb;
+      background: rgba(127, 86, 217, 0.12);
+      border: 1px solid rgba(127, 86, 217, 0.16);
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .breadcrumb-home-icon {
+      width: 16px;
+      height: 16px;
+      color: #98a2b3;
+      flex: 0 0 auto;
+    }
+
+    .breadcrumb-chevron {
+      width: 14px;
+      height: 14px;
+      color: #667085;
+      flex: 0 0 auto;
+    }
+
+    .section-title strong {
+      display: block;
+      font-size: 18px;
+      letter-spacing: -0.01em;
+    }
+
+    .section-title span {
+      display: block;
+      color: var(--text-tertiary);
+      margin-top: 4px;
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text-secondary);
+    }
+
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .metric-card {
+      padding: 10px 12px;
+      border-radius: 12px;
+      border: 1px solid #1f2937;
+      background: #111827;
+      box-shadow: none;
+    }
+
+    .metric-card small {
+      display: block;
+      color: var(--text-muted);
+      font-weight: 500;
+      margin-bottom: 4px;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .metric-card strong {
+      display: block;
+      font-size: 18px;
+      line-height: 1;
+      letter-spacing: -0.02em;
+      margin-bottom: 3px;
+      color: var(--text-secondary);
+    }
+
+    .metric-card span {
+      display: block;
+      color: var(--text-tertiary);
+      font-size: 11px;
+    }
+
+    .content-2col {
+      display: grid;
+      grid-template-columns: 1.25fr 0.95fr;
+      gap: 16px;
+      align-items: start;
+    }
+
+    .content-reports {
+      display: grid;
+      grid-template-columns: 320px 1fr 280px;
+      gap: 16px;
+      align-items: start;
+    }
+
+    .settings-columns {
+      display: grid;
+      gap: 16px;
+    }
+
+    /* List/detail view toggle */
+    .settings-columns .panel-detail {
+      display: none;
+    }
+
+    .settings-columns.detail-active .panel-list {
+      display: none;
+    }
+
+    .settings-columns.detail-active .panel-detail {
+      display: block;
+    }
+
+    .stack { display: grid; gap: 16px; }
+
+    .panel {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      box-shadow: var(--shadow-sm);
+      overflow: hidden;
+    }
+
+    .panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 16px 18px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .panel-header strong {
+      font-size: 16px;
+      letter-spacing: -0.01em;
+    }
+
+    .panel-header span {
+      color: var(--text-tertiary);
+      font-size: 13px;
+    }
+
+    .panel-body { padding: 18px; }
+
+    .list-toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 14px;
+      flex-wrap: wrap;
+    }
+
+    .list-toolbar .filters {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .filter-pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 8px 10px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--surface-alt);
+      color: var(--text-secondary);
+      font-size: 13px;
+    }
+
+    .policy-table-shell {
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      overflow: hidden;
+      background: var(--surface-alt);
+    }
+
+    .policy-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+
+    .policy-table th,
+    .policy-table td {
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--border);
+      text-align: left;
+      vertical-align: middle;
+    }
+
+    .policy-table th {
+      background: #111827;
+      color: var(--text-muted);
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .policy-table tr.active-row {
+      background: var(--brand-soft);
+    }
+
+    .policy-name {
+      display: grid;
+      gap: 2px;
+    }
+
+    .policy-name strong {
+      font-size: 13px;
+      margin: 0;
+    }
+
+    .policy-name span {
+      color: var(--text-tertiary);
+      font-size: 12px;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 4px 8px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 500;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text-secondary);
+    }
+
+    .status-pill.brand {
+      background: var(--brand-soft);
+      border-color: var(--brand-border);
+      color: var(--brand);
+    }
+
+    .list {
+      display: grid;
+      gap: 10px;
+    }
+
+    .list-card {
+      padding: 14px;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--surface-alt);
+    }
+
+    .list-card.active {
+      border-color: var(--brand-border);
+      background: var(--brand-soft);
+    }
+
+    .list-card strong,
+    .settings-card strong,
+    .mode-card strong,
+    .side-note strong,
+    .insight-card strong,
+    .table-card strong {
+      display: block;
+      margin-bottom: 4px;
+      font-size: 15px;
+    }
+
+    .list-card span,
+    .list-card small,
+    .meta-card span,
+    .settings-card span,
+    .side-note span,
+    .code-caption,
+    .table-subtle,
+    .mode-card span,
+    .insight-card span {
+      color: var(--text-tertiary);
+    }
+
+    .meta-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .selected-policy-layout {
+      display: grid;
+      gap: 16px;
+      align-items: start;
+    }
+
+    .selected-policy-meta,
+    .selected-policy-settings {
+      display: grid;
+      gap: 12px;
+      align-content: start;
+    }
+
+    .selected-policy-settings-list {
+      max-height: 3840px;
+      overflow-y: auto;
+      overflow-x: hidden;
+      display: grid;
+      gap: 12px;
+      padding: 8px;
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      background: rgba(11, 18, 32, 0.55);
+    }
+
+    .selected-policy-settings-list::-webkit-scrollbar {
+      width: 10px;
+    }
+
+    .selected-policy-settings-list::-webkit-scrollbar-thumb {
+      background: #243244;
+      border-radius: 999px;
+      border: 2px solid rgba(11, 18, 32, 0.55);
+    }
+
+    .meta-subtle {
+      display: block;
+      margin-top: 6px;
+      color: var(--text-muted);
+      font-size: 12px;
+      line-height: 1.4;
+      word-break: break-word;
+    }
+
+    .setting-group {
+      display: grid;
+      gap: 12px;
+      padding: 14px;
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      background: rgba(16, 24, 40, 0.58);
+    }
+
+    .setting-group-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .setting-group-header strong {
+      font-size: 14px;
+      margin: 0;
+    }
+
+    .setting-group-header span {
+      color: var(--text-muted);
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .setting-group-cards {
+      display: grid;
+      gap: 12px;
+    }
+
+    .setting-group-cards .settings-card {
+      margin-bottom: 0;
+    }
+
+    .selected-policy-meta .meta-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .selected-policy-meta .meta-card {
+      padding: 12px;
+    }
+
+    .selected-policy-meta .meta-card span {
+      font-size: 13px;
+    }
+
+    .selected-policy-toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .selected-policy-settings .inline-tags {
+      margin-top: 0;
+      margin-bottom: 4px;
+    }
+
+    .settings-search {
+      min-width: 280px;
+      max-width: 360px;
+      padding: 9px 12px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--bg-soft);
+      color: var(--text-secondary);
+    }
+
+    .selected-policy-settings .settings-card {
+      margin-bottom: 0;
+    }
+
+    .meta-card {
+      padding: 14px;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--surface-alt);
+    }
+
+    .meta-card small {
+      display: block;
+      margin-bottom: 6px;
+      color: var(--text-muted);
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .inline-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 10px;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      padding: 6px 10px;
+      border-radius: 999px;
+      background: var(--bg-soft);
+      border: 1px solid var(--border);
+      color: var(--text-secondary);
+      font-size: 12px;
+      font-weight: 500;
+    }
+
+    .settings-card {
+      position: relative;
+      padding: 16px;
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      background: var(--surface-alt);
+      margin-bottom: 12px;
+    }
+
+    .setting-top {
+      display: flex;
+      justify-content: space-between;
+      align-items: start;
+      gap: 16px;
+      margin-bottom: 12px;
+    }
+
+    .setting-value {
+      min-width: 120px;
+      max-width: 260px;
+      padding: 8px 12px;
+      border-radius: 10px;
+      background: var(--blue-soft);
+      border: 1px solid rgba(96, 165, 250, 0.25);
+      text-align: right;
+      color: var(--blue);
+      font-size: 12px;
+      font-weight: 600;
+    }
+
+    .setting-value.val-enabled {
+      background: var(--success-soft);
+      border-color: rgba(74, 222, 128, 0.25);
+      color: var(--success);
+    }
+
+    .setting-value.val-disabled {
+      background: var(--error-soft);
+      border-color: rgba(251, 113, 133, 0.25);
+      color: var(--error);
+    }
+
+    .setting-value.val-numeric {
+      background: var(--blue-soft);
+      border-color: rgba(96, 165, 250, 0.25);
+      color: var(--blue);
+    }
+
+    .setting-value.val-complex {
+      background: var(--brand-soft);
+      border-color: var(--brand-border);
+      color: var(--brand);
+    }
+
+    .setting-tooltip {
+      position: absolute;
+      left: 16px;
+      right: 16px;
+      bottom: calc(100% + 10px);
+      padding: 10px 12px;
+      border-radius: 12px;
+      border: 1px solid var(--border-strong);
+      background: rgba(10, 15, 30, 0.96);
+      color: var(--text-secondary);
+      box-shadow: var(--shadow-md);
+      opacity: 0;
+      transform: translateY(6px);
+      pointer-events: none;
+      transition: opacity 0.16s ease, transform 0.16s ease;
+      z-index: 20;
+    }
+
+    .settings-card:hover .setting-tooltip,
+    .settings-card:focus-within .setting-tooltip {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .side-note {
+      padding: 16px;
+      border-radius: 14px;
+      border: 1px solid var(--border);
+      background: var(--surface-alt);
+      margin-bottom: 12px;
+    }
+
+    .side-note ul {
+      margin: 10px 0 0;
+      padding-left: 18px;
+      color: var(--text-tertiary);
+      display: grid;
+      gap: 8px;
+    }
+
+    .health-grid {
+      display: grid;
+      grid-template-columns: 1.2fr 0.8fr;
+      gap: 16px;
+      align-items: start;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+
+    th, td {
+      padding: 12px 10px;
+      border-bottom: 1px solid var(--border);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    th {
+      color: var(--text-muted);
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 4px 8px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 500;
+      border: 1px solid transparent;
+    }
+
+    .badge.success {
+      background: var(--success-soft);
+      color: var(--success);
+      border-color: #abefc6;
+    }
+
+    .badge.warning {
+      background: var(--warning-soft);
+      color: var(--warning);
+      border-color: #fedf89;
+    }
+
+    .badge.error {
+      background: var(--error-soft);
+      color: var(--error);
+      border-color: #fecdca;
+    }
+
+    .code-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+    }
+
+    .code-card {
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      overflow: hidden;
+      background: #0c111d;
+    }
+
+    .code-card .head {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      align-items: center;
+      padding: 14px 16px;
+      background: #101828;
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+      color: #f9fafb;
+    }
+
+    pre {
+      margin: 0;
+      padding: 16px;
+      overflow: hidden;
+      white-space: pre-wrap;
+      color: #d0d5dd;
+      font: 12px/1.6 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+
+    .mode-list,
+    .mini-metrics,
+    .chart-list {
+      display: grid;
+      gap: 10px;
+    }
+
+    .mode-card,
+    .insight-card,
+    .table-card {
+      padding: 14px;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--surface-alt);
+    }
+
+    .mode-card.active {
+      background: var(--brand-soft);
+      border-color: var(--brand-border);
+    }
+
+    .mini-metrics {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .mini-metric {
+      padding: 14px;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--surface-alt);
+    }
+
+    .mini-metric strong {
+      display: block;
+      font-size: 24px;
+      line-height: 1;
+      margin-bottom: 6px;
+    }
+
+    .mini-metric span { color: var(--text-tertiary); }
+
+    .bar-row { display: grid; gap: 6px; }
+
+    .bar-row label {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      color: var(--text-secondary);
+    }
+
+    .bar {
+      height: 10px;
+      border-radius: 999px;
+      background: #1e293b;
+      overflow: hidden;
+    }
+
+    .bar span {
+      display: block;
+      height: 100%;
+      border-radius: inherit;
+      background: linear-gradient(90deg, #9e77ed 0%, #7f56d9 100%);
+    }
+
+    .footer-note {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 14px 16px;
+      border-top: 1px solid var(--border);
+      color: var(--text-tertiary);
+      background: var(--surface);
+      font-size: 13px;
+    }
+
+    /* Row hover for policy table */
+    .policy-table tr {
+      cursor: pointer;
+      transition: background 0.12s ease;
+    }
+
+    .policy-table tr:hover:not(.active-row) {
+      background: rgba(255, 255, 255, 0.02);
+    }
+
+    /* Action button in table rows */
+    .col-actions {
+      width: 100px;
+      text-align: right;
+    }
+
+    .view-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 12px;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text-secondary);
+      font-size: 12px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.12s ease;
+    }
+
+    .view-btn:hover {
+      background: var(--brand-soft);
+      border-color: var(--brand-border);
+      color: var(--brand);
+    }
+
+    .view-btn svg {
+      width: 14px;
+      height: 14px;
+    }
+
+    /* Back button in detail view */
+    .back-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 14px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text-secondary);
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.12s ease;
+    }
+
+    .back-btn:hover {
+      background: rgba(255, 255, 255, 0.04);
+      color: var(--text);
+    }
+
+    .back-btn svg {
+      width: 16px;
+      height: 16px;
+    }
+
+    .detail-header-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 4px;
+    }
+
+    /* Inline stats bar (replaces metric cards) */
+    .inline-stats {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+
+    .inline-stat {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 12px;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: var(--surface-alt);
+      font-size: 12px;
+      color: var(--text-secondary);
+    }
+
+    .inline-stat strong {
+      color: var(--text);
+      font-size: 14px;
+    }
+
+    .inline-stat-divider {
+      width: 1px;
+      height: 20px;
+      background: var(--border);
+      margin: 0 4px;
+    }
+
+    /* Collapsible meta section */
+    .meta-primary {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .meta-advanced {
+      display: none;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 12px;
+    }
+
+    .meta-advanced.open {
+      display: grid;
+    }
+
+    .meta-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 12px;
+      padding: 6px 12px;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--text-muted);
+      font-size: 12px;
+      cursor: pointer;
+      transition: all 0.12s ease;
+    }
+
+    .meta-toggle:hover {
+      color: var(--text-secondary);
+      background: rgba(255, 255, 255, 0.02);
+    }
+
+    .meta-toggle svg {
+      width: 14px;
+      height: 14px;
+      transition: transform 0.2s ease;
+    }
+
+    .meta-toggle.open svg {
+      transform: rotate(180deg);
+    }
+
+    @media (max-width: 1280px) {
+      .summary-banner,
+      .main-grid,
+      .metrics,
+      .content-2col,
+      .content-reports,
+      .settings-columns,
+      .selected-policy-layout,
+      .code-grid,
+      .meta-grid,
+      .health-grid,
+      .mini-metrics {
+        grid-template-columns: 1fr;
+      }
+
+      .settings-columns {
+        height: auto;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="switcher">
+      <button class="active" data-target="settings">Settings Catalog</button>
+      <button data-target="health">Device Health Scripts</button>
+      <button data-target="reports">Reports and dashboards</button>
+    </div>
+
+    <section class="app-shell">
+      <div class="shell-topbar">
+        <div class="shell-header-primary">
+          <div class="topbar-left">
+            <div class="product-mark"></div>
+            <div class="product-copy">
+              <strong>Intune Commander</strong>
+              <span>Local desktop shell</span>
+            </div>
+          </div>
+          <div class="topbar-right">
+            <span class="header-status">Contoso Production / Commercial</span>
+            <input class="search" value="Search profiles, scripts, and reports..." readonly>
+            <button class="secondary-btn">Export</button>
+          </div>
+        </div>
+        <div class="shell-header-secondary">
+          <div class="primary-nav">
+            <span class="nav-tier-link active">Configuration</span>
+            <span class="nav-tier-link">Endpoint security</span>
+            <span class="nav-tier-link">Devices</span>
+            <span class="nav-tier-link">Reports</span>
+            <span class="nav-tier-link">Automation</span>
+          </div>
+          <div class="secondary-nav">
+            <span class="nav-tier-link secondary active">Configuration profiles</span>
+            <span class="nav-tier-link secondary">Device health scripts</span>
+            <span class="nav-tier-link secondary">Assignment reports</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="main-grid">
+        <aside class="sidebar">
+          <div class="sidebar-panel">
+            <div class="sidebar-panel-header">
+              <strong>Devices</strong>
+              <span>Configuration and reporting menu</span>
+            </div>
+
+            <div class="sidebar-menu-search">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="11" cy="11" r="7"></circle>
+                <path d="m20 20-3.5-3.5"></path>
+              </svg>
+              <input type="text" value="Search" readonly>
+            </div>
+
+            <div class="nav-group">
+              <div class="nav-label">Quick access</div>
+              <div class="nav-item">
+                <span class="nav-item-main">
+                  <svg viewBox="0 0 24 24" class="nav-item-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M3 12h18M12 3v18"></path>
+                  </svg>
+                  <span class="nav-item-label">Overview</span>
+                </span>
+              </div>
+              <div class="nav-item">
+                <span class="nav-item-main">
+                  <svg viewBox="0 0 24 24" class="nav-item-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <rect x="4" y="4" width="16" height="16" rx="2"></rect>
+                    <path d="M8 9h8M8 13h8M8 17h5"></path>
+                  </svg>
+                  <span class="nav-item-label">Configuration profiles</span>
+                </span>
+                <small>204</small>
+              </div>
+              <div class="nav-item">
+                <span class="nav-item-main">
+                  <svg viewBox="0 0 24 24" class="nav-item-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M4 12h3l2-4 4 8 2-4h5"></path>
+                  </svg>
+                  <span class="nav-item-label">Device health scripts</span>
+                </span>
+              </div>
+              <div class="nav-item">
+                <span class="nav-item-main">
+                  <svg viewBox="0 0 24 24" class="nav-item-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M6 18V10M12 18V6M18 18v-4"></path>
+                  </svg>
+                  <span class="nav-item-label">Assignment reports</span>
+                </span>
+                <small>53</small>
+              </div>
+            </div>
+
+            <div class="nav-group">
+              <div class="nav-label">Favorites</div>
+              <div class="nav-item active">
+                <span class="nav-item-main">
+                  <svg viewBox="0 0 24 24" class="nav-item-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M4 7h16M7 4v6M17 14v6M4 17h16"></path>
+                  </svg>
+                  <span class="nav-item-label">Settings Catalog</span>
+                </span>
+                <small>96</small>
+              </div>
+              <div class="nav-item">
+                <span class="nav-item-main">
+                  <svg viewBox="0 0 24 24" class="nav-item-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M12 3v18M5 8h14M7 21h10"></path>
+                  </svg>
+                  <span class="nav-item-label">Device Security</span>
+                </span>
+              </div>
+              <div class="nav-item">
+                <span class="nav-item-main">
+                  <svg viewBox="0 0 24 24" class="nav-item-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M12 2l7 4v6c0 5-3.5 8-7 10-3.5-2-7-5-7-10V6z"></path>
+                  </svg>
+                  <span class="nav-item-label">Direct assignments</span>
+                </span>
+                <small>1</small>
+              </div>
+            </div>
+
+            <div class="nav-group">
+              <div class="nav-label">By platform</div>
+              <div class="nav-item">
+                <span class="nav-item-main">
+                  <svg viewBox="0 0 24 24" class="nav-item-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <rect x="3" y="5" width="18" height="12" rx="2"></rect>
+                    <path d="M8 21h8"></path>
+                  </svg>
+                  <span class="nav-item-label">Windows 10 and later</span>
+                </span>
+              </div>
+              <div class="nav-item">
+                <span class="nav-item-main">
+                  <svg viewBox="0 0 24 24" class="nav-item-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M8 3h8M9 3v3m6-3v3M7 21h10M8 18h8"></path>
+                    <rect x="6" y="6" width="12" height="12" rx="3"></rect>
+                  </svg>
+                  <span class="nav-item-label">macOS</span>
+                </span>
+              </div>
+              <div class="nav-item">
+                <span class="nav-item-main">
+                  <svg viewBox="0 0 24 24" class="nav-item-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <rect x="7" y="2" width="10" height="20" rx="3"></rect>
+                    <path d="M11 18h2"></path>
+                  </svg>
+                  <span class="nav-item-label">iOS/iPadOS</span>
+                </span>
+              </div>
+              <div class="nav-item">
+                <span class="nav-item-main">
+                  <svg viewBox="0 0 24 24" class="nav-item-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M7 5h10M9 3v2m6-2v2M8 19h8M6 7h12v10H6z"></path>
+                  </svg>
+                  <span class="nav-item-label">Android Enterprise</span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </aside>
+
+        <main>
+          <section id="settings" class="workspace active">
+            <ol aria-label="Breadcrumbs" class="breadcrumb section-breadcrumb">
+              <li class="breadcrumb-item">
+                <span class="breadcrumb-link icon-only" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" class="breadcrumb-home-icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M3 10.6c0-.57 0-.86.07-1.12.08-.27.19-.49.36-.72.16-.22.39-.39.84-.74l6.01-4.67c.35-.27.52-.41.72-.46a1 1 0 0 1 .52 0c.2.05.37.19.72.46l6.01 4.67c.45.35.68.52.84.74.17.23.28.45.36.72.07.26.07.55.07 1.12V18c0 1.12 0 1.68-.22 2.11a2 2 0 0 1-.87.87C18.68 21 18.12 21 17 21H7c-1.12 0-1.68 0-2.11-.22a2 2 0 0 1-.87-.87C3 19.68 3 19.12 3 18z"/>
+                  </svg>
+                </span>
+                <svg viewBox="0 0 24 24" class="breadcrumb-chevron" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="m9 18 6-6-6-6"/>
+                </svg>
+              </li>
+              <li class="breadcrumb-item">
+                <span class="breadcrumb-link">Devices</span>
+                <svg viewBox="0 0 24 24" class="breadcrumb-chevron" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="m9 18 6-6-6-6"/>
+                </svg>
+              </li>
+              <li class="breadcrumb-item">
+                <span class="breadcrumb-link">Configuration profiles</span>
+                <svg viewBox="0 0 24 24" class="breadcrumb-chevron" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="m9 18 6-6-6-6"/>
+                </svg>
+              </li>
+              <li class="breadcrumb-item">
+                <span class="breadcrumb-link">Windows</span>
+                <svg viewBox="0 0 24 24" class="breadcrumb-chevron" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="m9 18 6-6-6-6"/>
+                </svg>
+              </li>
+              <li class="breadcrumb-item">
+                <span class="breadcrumb-link">Settings Catalog</span>
+                <svg viewBox="0 0 24 24" class="breadcrumb-chevron" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="m9 18 6-6-6-6"/>
+                </svg>
+              </li>
+              <li class="breadcrumb-item current">
+                <span class="breadcrumb-current">Policy list</span>
+              </li>
+            </ol>
+            <div class="section-toolbar">
+              <div class="section-heading">
+                <div class="section-title">
+                  <strong>Settings Catalog</strong>
+                </div>
+                <div class="inline-stats" style="margin-top:8px;">
+                  <span class="inline-stat"><strong>204</strong> policies</span>
+                  <span class="inline-stat-divider"></span>
+                  <span class="inline-stat"><strong>96</strong> settings in selected</span>
+                  <span class="inline-stat-divider"></span>
+                  <span class="inline-stat"><strong>1</strong> assignment</span>
+                  <span class="inline-stat-divider"></span>
+                  <span class="inline-stat"><strong>1</strong> scope tag</span>
+                </div>
+              </div>
+              <div class="toolbar-right">
+                <button class="secondary-btn">Columns</button>
+                <button class="primary-btn">Export selected</button>
+              </div>
+            </div>
+
+            <div class="settings-columns" id="settingsColumns">
+              <div class="panel panel-list">
+                <div class="panel-header">
+                  <strong>Policy list</strong>
+                  <span>204 policies</span>
+                </div>
+                <div class="panel-body">
+                  <div class="policy-table-shell">
+                    <table class="policy-table">
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th class="col-platform">Platform</th>
+                          <th>Profile type</th>
+                          <th class="col-modified">Modified</th>
+                          <th class="col-scope">Scope tag</th>
+                          <th class="col-actions"></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr class="active-row">
+                          <td>
+                            <div class="policy-name">
+                              <strong>Win - OIB - SC - Device Security - D - Security Hardening - vModified</strong>
+                              <span>Opened from the exported policy JSON</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>Settings catalog</td>
+                          <td class="col-modified">2/10/2026, 8:26:42 PM</td>
+                          <td class="col-scope"><span class="status-pill brand">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>AdamGell-ManagedDevice-Device features</strong>
+                              <span>Managed device profile</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">iOS/iPadOS</td>
+                          <td>Device features</td>
+                          <td class="col-modified">11/3/2025, 10:25:01 AM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>AdamGell-ManagedDevice-Device restrictions</strong>
+                              <span>Managed device profile</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">iOS/iPadOS</td>
+                          <td>Device restrictions</td>
+                          <td class="col-modified">9/22/2025, 11:37:20 AM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>AdamGell-ManagedDevice-MSTunnel</strong>
+                              <span>Managed device profile</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">iOS/iPadOS</td>
+                          <td>VPN</td>
+                          <td class="col-modified">1/6/2026, 3:00:40 PM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>All Devices - Windows Health monitoring</strong>
+                              <span>Windows health monitoring</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>Windows health monitoring</td>
+                          <td class="col-modified">12/19/2025, 9:56:44 AM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Applocker Policy - Created 2025-10-20 115557 by Adam.Gell@CDWWorkspaceLabs.onmicrosoft.com</strong>
+                              <span>Custom policy</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>Custom</td>
+                          <td class="col-modified">10/21/2025, 11:02:56 AM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Calendar widget</strong>
+                              <span>Android profile</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Android Enterprise</td>
+                          <td>Device restrictions</td>
+                          <td class="col-modified">9/10/2025, 2:38:38 AM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>DDM - OS Updates</strong>
+                              <span>Declarative management</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">macOS</td>
+                          <td>Settings catalog</td>
+                          <td class="col-modified">10/13/2025, 4:07:40 PM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Enable Secure Boot Updates</strong>
+                              <span>Windows baseline hardening</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>Settings catalog</td>
+                          <td class="col-modified">2/2/2026, 3:23:46 PM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Enroll all Windows Devices</strong>
+                              <span>Endpoint onboarding</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>Endpoint detection and response</td>
+                          <td class="col-modified">7/30/2025, 10:58:01 AM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>FileVault - Full Disk Encryption for macOS - Profayne Demo</strong>
+                              <span>macOS encryption</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">macOS</td>
+                          <td>MacOS Filevault</td>
+                          <td class="col-modified">4/22/2025, 1:19:00 PM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Gell - Enable local administrator account (Win11 23H2 and lower)</strong>
+                              <span>Windows admin controls</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>Settings catalog</td>
+                          <td class="col-modified">8/1/2025, 10:17:58 AM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Gell - EPM - Settings Policy</strong>
+                              <span>Elevation controls</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>Elevation settings policy</td>
+                          <td class="col-modified">5/7/2025, 12:17:42 PM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Gell - Filevault</strong>
+                              <span>macOS encryption</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">macOS</td>
+                          <td>MacOS Filevault</td>
+                          <td class="col-modified">11/4/2025, 10:59:17 PM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Gell - Groff Wi-Fi</strong>
+                              <span>Network configuration</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>Wi-Fi</td>
+                          <td class="col-modified">12/19/2025, 10:53:26 AM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Gell - Issuing Cert</strong>
+                              <span>Certificate profile</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 8.1 and later</td>
+                          <td>Trusted certificate</td>
+                          <td class="col-modified">3/20/2025, 12:47:30 PM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Gell - Root Trusted Cert</strong>
+                              <span>Certificate profile</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 8.1 and later</td>
+                          <td>Trusted certificate</td>
+                          <td class="col-modified">3/20/2025, 12:38:53 PM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Gell - SCEP Cert</strong>
+                              <span>Certificate profile</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 8.1 and later</td>
+                          <td>SCEP certificate</td>
+                          <td class="col-modified">10/28/2025, 10:20:09 AM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Gell - Win - OIB - SC - Windows Update for Business - D - Delivery Optimisation - v3.0</strong>
+                              <span>Windows Update for Business</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>Settings catalog</td>
+                          <td class="col-modified">1/5/2026, 11:36:49 AM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Generated PolicyAgent Policy</strong>
+                              <span>Generated configuration profile</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>Settings catalog</td>
+                          <td class="col-modified">1/23/2026, 1:14:40 PM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Generated PolicyAgent Policy</strong>
+                              <span>Generated configuration profile</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>Settings catalog</td>
+                          <td class="col-modified">11/26/2025, 2:06:26 PM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Gibson Bitlocker</strong>
+                              <span>BitLocker policy</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>BitLocker</td>
+                          <td class="col-modified">1/5/2026, 1:22:50 AM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Gibson Domain</strong>
+                              <span>Domain join</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>Domain join</td>
+                          <td class="col-modified">12/15/2025, 7:35:11 PM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                        <tr>
+                          <td>
+                            <div class="policy-name">
+                              <strong>Gibson-LAPS</strong>
+                              <span>Local admin password solution</span>
+                            </div>
+                          </td>
+                          <td class="col-platform">Windows 10 and later</td>
+                          <td>Local admin password solution (Windows LAPS)</td>
+                          <td class="col-modified">3/3/2026, 12:30:57 PM</td>
+                          <td class="col-scope"><span class="status-pill">Default</span></td>
+                          <td class="col-actions"><button class="view-btn" onclick="showDetail()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>View</button></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+
+              <div class="panel panel-detail">
+                <div class="panel-header">
+                  <div class="detail-header-row">
+                    <button class="back-btn" onclick="showList()">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+                      Back to list
+                    </button>
+                    <div style="display:flex;align-items:center;gap:10px;">
+                      <button class="secondary-btn">Export JSON</button>
+                      <button class="primary-btn">Edit policy</button>
+                    </div>
+                  </div>
+                </div>
+                <div class="panel-body">
+                  <div class="section-title" style="margin-bottom:16px;">
+                    <strong>Win - OIB - SC - Device Security - D - Security Hardening - vModified</strong>
+                    <span>Settings catalog &middot; Windows 10 and later</span>
+                  </div>
+                  <div class="selected-policy-layout">
+                    <div class="selected-policy-meta">
+                      <div class="meta-primary">
+                        <div class="meta-card">
+                          <small>Platform</small>
+                          <span>Windows 10 and later / mdm</span>
+                        </div>
+                        <div class="meta-card">
+                          <small>Lifecycle</small>
+                          <span>Created 1/28/2026</span>
+                          <span class="meta-subtle">Modified 2/10/2026</span>
+                        </div>
+                        <div class="meta-card">
+                          <small>Assignment</small>
+                          <span>1 direct group assignment</span>
+                        </div>
+                      </div>
+                      <div class="meta-advanced" id="metaAdvanced">
+                        <div class="meta-card">
+                          <small>Policy identity</small>
+                          <span>1648d70e-6141-4e45-b6bf-45334f858b20</span>
+                          <span class="meta-subtle">Creation source: None</span>
+                        </div>
+                        <div class="meta-card">
+                          <small>Scope and template</small>
+                          <span>Role scope tag IDs: 0</span>
+                          <span class="meta-subtle">Template family: none / Template ID: None</span>
+                        </div>
+                        <div class="meta-card">
+                          <small>Assignment detail</small>
+                          <span>Group 02841bce...74c01</span>
+                          <span class="meta-subtle">Filter none / groupAssignmentTarget</span>
+                        </div>
+                      </div>
+                      <button class="meta-toggle" id="metaToggle" onclick="toggleMeta()">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+                        Show advanced details
+                      </button>
+                    </div>
+                    <div class="selected-policy-settings">
+                      <div class="selected-policy-toolbar">
+                        <div class="inline-tags">
+                          <span class="tag">96 settings</span>
+                          <span class="tag">1 direct assignment</span>
+                          <span class="tag">Grouped by category</span>
+                        </div>
+                        <input class="settings-search" type="text" placeholder="Search 96 settings" readonly>
+                      </div>
+
+                      <div class="selected-policy-settings-list">
+                        <section class="setting-group">
+                          <div class="setting-group-header">
+                            <strong>Microsoft Security Guide</strong>
+                            <span>5 settings</span>
+                          </div>
+                          <div class="setting-group-cards">
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>MS Security Guide Apply UAC restrictions to local accounts on network logon</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_mssecurityguide_applyuacrestrictionstolocalaccountsonnetworklogon | Raw choice: device_vendor_msft_policy_config_mssecurityguide_applyuacrestrictionstolocalaccountsonnetworklogon_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>MS Security Guide Configure SMBv1 client driver</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / MS Security Guide Configure SMBv1 client driver Secguide Smb1clientdriver: Option 4</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_mssecurityguide_configuresmbv1clientdriver | Raw choice: device_vendor_msft_policy_config_mssecurityguide_configuresmbv1clientdriver_1 | device_vendor_msft_policy_config_mssecurityguide_configuresmbv1clientdriver_pol_secguide_smb1clientdriver: device_vendor_msft_policy_config_mssecurityguide_configuresmbv1clientdriver_pol_secguide_smb1clientdriver_4</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>MS Security Guide Configure SMBv1 server</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_mssecurityguide_configuresmbv1server | Raw choice: device_vendor_msft_policy_config_mssecurityguide_configuresmbv1server_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>MS Security Guide Enablestructuredexceptionhandlingoverwriteprotection</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_mssecurityguide_enablestructuredexceptionhandlingoverwriteprotection | Raw choice: device_vendor_msft_policy_config_mssecurityguide_enablestructuredexceptionhandlingoverwriteprotection_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>MS Security Guide WDigest authentication</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_mssecurityguide_wdigestauthentication | Raw choice: device_vendor_msft_policy_config_mssecurityguide_wdigestauthentication_0</span>
+                          </div>
+                          </div>
+                        </section>
+
+                        <section class="setting-group">
+                          <div class="setting-group-header">
+                            <strong>MSS legacy</strong>
+                            <span>4 settings</span>
+                          </div>
+                          <div class="setting-group-cards">
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>MSS legacy Ipv6sourceroutingprotectionlevel</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / MSS legacy Ipv6sourceroutingprotectionlevel Disableipsourceroutingipv6: Option 2</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_msslegacy_ipv6sourceroutingprotectionlevel | Raw choice: device_vendor_msft_policy_config_msslegacy_ipv6sourceroutingprotectionlevel_1 | device_vendor_msft_policy_config_msslegacy_ipv6sourceroutingprotectionlevel_disableipsourceroutingipv6: device_vendor_msft_policy_config_msslegacy_ipv6sourceroutingprotectionlevel_disableipsourceroutingipv6_2</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>MSS legacy Ipsourceroutingprotectionlevel</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / MSS legacy Ipsourceroutingprotectionlevel Disableipsourcerouting: Option 2</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_msslegacy_ipsourceroutingprotectionlevel | Raw choice: device_vendor_msft_policy_config_msslegacy_ipsourceroutingprotectionlevel_1 | device_vendor_msft_policy_config_msslegacy_ipsourceroutingprotectionlevel_disableipsourcerouting: device_vendor_msft_policy_config_msslegacy_ipsourceroutingprotectionlevel_disableipsourcerouting_2</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>MSS legacy Allowicmpredirectstooverrideospfgeneratedroutes</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_msslegacy_allowicmpredirectstooverrideospfgeneratedroutes | Raw choice: device_vendor_msft_policy_config_msslegacy_allowicmpredirectstooverrideospfgeneratedroutes_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>MSS legacy Allowthecomputertoignorenetbiosnamereleaserequestsexceptfromwinsservers</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_msslegacy_allowthecomputertoignorenetbiosnamereleaserequestsexceptfromwinsservers | Raw choice: device_vendor_msft_policy_config_msslegacy_allowthecomputertoignorenetbiosnamereleaserequestsexceptfromwinsservers_1</span>
+                          </div>
+                          </div>
+                        </section>
+
+                        <section class="setting-group">
+                          <div class="setting-group-header">
+                            <strong>Network and connectivity</strong>
+                            <span>27 settings</span>
+                          </div>
+                          <div class="setting-group-cards">
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Connectivity Prohibitinstallationandconfigurationofnetworkbridge</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_connectivity_prohibitinstallationandconfigurationofnetworkbridge | Raw choice: device_vendor_msft_policy_config_connectivity_prohibitinstallationandconfigurationofnetworkbridge_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Connectivity Hardened UNC paths</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / \\*\SYSVOL + \\*\NETLOGON</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_connectivity_hardeneduncpaths | Raw choice: device_vendor_msft_policy_config_connectivity_hardeneduncpaths_1 | \\*\SYSVOL =&gt; RequireMutualAuthentication=1, RequireIntegrity=1, RequirePrivacy=1 | \\*\NETLOGON =&gt; RequireMutualAuthentication=1, RequireIntegrity=1, RequirePrivacy=1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Windows connection manager Prohitconnectiontonondomainnetworkswhenconnectedtodomainauthenticatednetwork</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_windowsconnectionmanager_prohitconnectiontonondomainnetworkswhenconnectedtodomainauthenticatednetwork | Raw choice: device_vendor_msft_policy_config_windowsconnectionmanager_prohitconnectiontonondomainnetworkswhenconnectedtodomainauthenticatednetwork_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Connectivity Disabledownloadingofprintdriversoverhttp</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_connectivity_disabledownloadingofprintdriversoverhttp | Raw choice: device_vendor_msft_policy_config_connectivity_disabledownloadingofprintdriversoverhttp_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Connectivity Disableinternetdownloadforwebpublishingandonlineorderingwizards</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_connectivity_disableinternetdownloadforwebpublishingandonlineorderingwizards | Raw choice: device_vendor_msft_policy_config_connectivity_disableinternetdownloadforwebpublishingandonlineorderingwizards_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Connectivity Allowphonepclinking</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_connectivity_allowphonepclinking | Raw choice: device_vendor_msft_policy_config_connectivity_allowphonepclinking_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanserver Auditclientdoesnotsupportencryption</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanserver_auditclientdoesnotsupportencryption | Raw choice: device_vendor_msft_policy_config_lanmanserver_auditclientdoesnotsupportencryption_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanserver Auditclientdoesnotsupportsigning</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanserver_auditclientdoesnotsupportsigning | Raw choice: device_vendor_msft_policy_config_lanmanserver_auditclientdoesnotsupportsigning_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanserver Auditinsecureguestlogon</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanserver_auditinsecureguestlogon | Raw choice: device_vendor_msft_policy_config_lanmanserver_auditinsecureguestlogon_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanserver Authratelimiterdelayinms</strong>
+                              </div>
+                              <div class="setting-value val-numeric">2000</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanserver_authratelimiterdelayinms | Raw value: 2000</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanserver Enableauthratelimiter</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanserver_enableauthratelimiter | Raw choice: device_vendor_msft_policy_config_lanmanserver_enableauthratelimiter_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanserver Enablemailslots</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanserver_enablemailslots | Raw choice: device_vendor_msft_policy_config_lanmanserver_enablemailslots_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanserver Maxsmb2dialect</strong>
+                              </div>
+                              <div class="setting-value val-numeric">Option 785</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanserver_maxsmb2dialect | Raw choice: device_vendor_msft_policy_config_lanmanserver_maxsmb2dialect_785</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanserver Minsmb2dialect</strong>
+                              </div>
+                              <div class="setting-value val-numeric">Option 768</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanserver_minsmb2dialect | Raw choice: device_vendor_msft_policy_config_lanmanserver_minsmb2dialect_768</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanworkstation Auditinsecureguestlogon</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanworkstation_auditinsecureguestlogon | Raw choice: device_vendor_msft_policy_config_lanmanworkstation_auditinsecureguestlogon_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanworkstation Auditserverdoesnotsupportencryption</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanworkstation_auditserverdoesnotsupportencryption | Raw choice: device_vendor_msft_policy_config_lanmanworkstation_auditserverdoesnotsupportencryption_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanworkstation Auditserverdoesnotsupportsigning</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanworkstation_auditserverdoesnotsupportsigning | Raw choice: device_vendor_msft_policy_config_lanmanworkstation_auditserverdoesnotsupportsigning_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanworkstation Enableinsecureguestlogons</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanworkstation_enableinsecureguestlogons | Raw choice: device_vendor_msft_policy_config_lanmanworkstation_enableinsecureguestlogons_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanworkstation Enablemailslots</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanworkstation_enablemailslots | Raw choice: device_vendor_msft_policy_config_lanmanworkstation_enablemailslots_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanworkstation Maxsmb2dialect</strong>
+                              </div>
+                              <div class="setting-value val-numeric">Option 785</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanworkstation_maxsmb2dialect | Raw choice: device_vendor_msft_policy_config_lanmanworkstation_maxsmb2dialect_785</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanworkstation Minsmb2dialect</strong>
+                              </div>
+                              <div class="setting-value val-numeric">Option 768</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanworkstation_minsmb2dialect | Raw choice: device_vendor_msft_policy_config_lanmanworkstation_minsmb2dialect_768</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Lanmanworkstation Requireencryption</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_lanmanworkstation_requireencryption | Raw choice: device_vendor_msft_policy_config_lanmanworkstation_requireencryption_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Wi-Fi Allowautoconnecttowifisensehotspots</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_wifi_allowautoconnecttowifisensehotspots | Raw choice: device_vendor_msft_policy_config_wifi_allowautoconnecttowifisensehotspots_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Wi-Fi Allowinternetsharing</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_wifi_allowinternetsharing | Raw choice: device_vendor_msft_policy_config_wifi_allowinternetsharing_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Wireless display Allowprojectionfrompc</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_wirelessdisplay_allowprojectionfrompc | Raw choice: device_vendor_msft_policy_config_wirelessdisplay_allowprojectionfrompc_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Wireless display Allowprojectiontopc</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_wirelessdisplay_allowprojectiontopc | Raw choice: device_vendor_msft_policy_config_wirelessdisplay_allowprojectiontopc_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Wireless display Requirepinforpairing</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_wirelessdisplay_requirepinforpairing | Raw choice: device_vendor_msft_policy_config_wirelessdisplay_requirepinforpairing_1</span>
+                          </div>
+                          </div>
+                        </section>
+
+                        <section class="setting-group">
+                          <div class="setting-group-header">
+                            <strong>Credentials and remote access</strong>
+                            <span>14 settings</span>
+                          </div>
+                          <div class="setting-group-cards">
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>CredSSP Allow encryption oracle</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / CredSSP Allow encryption oracle Allowencryptionoracledrop: Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_credssp_allowencryptionoracle | Raw choice: device_vendor_msft_policy_config_admx_credssp_allowencryptionoracle_1 | device_vendor_msft_policy_config_admx_credssp_allowencryptionoracle_allowencryptionoracledrop: device_vendor_msft_policy_config_admx_credssp_allowencryptionoracle_allowencryptionoracledrop_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Credentials delegation Remotehostallowsdelegationofnonexportablecredentials</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_credentialsdelegation_remotehostallowsdelegationofnonexportablecredentials | Raw choice: device_vendor_msft_policy_config_credentialsdelegation_remotehostallowsdelegationofnonexportablecredentials_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Credential providers Blockpicturepassword</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_credentialproviders_blockpicturepassword | Raw choice: device_vendor_msft_policy_config_credentialproviders_blockpicturepassword_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Credential providers Allowpinlogon</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_credentialproviders_allowpinlogon | Raw choice: device_vendor_msft_policy_config_credentialproviders_allowpinlogon_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Remote assistance Unsolicitedremoteassistance</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_remoteassistance_unsolicitedremoteassistance | Raw choice: device_vendor_msft_policy_config_remoteassistance_unsolicitedremoteassistance_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Remote assistance Solicitedremoteassistance</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_remoteassistance_solicitedremoteassistance | Raw choice: device_vendor_msft_policy_config_remoteassistance_solicitedremoteassistance_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Credentials UI Enumerateadministrators</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_credentialsui_enumerateadministrators | Raw choice: device_vendor_msft_policy_config_credentialsui_enumerateadministrators_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Remote management Allowbasicauthentication Client</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_remotemanagement_allowbasicauthentication_client | Raw choice: device_vendor_msft_policy_config_remotemanagement_allowbasicauthentication_client_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Remote management Allowunencryptedtraffic Client</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_remotemanagement_allowunencryptedtraffic_client | Raw choice: device_vendor_msft_policy_config_remotemanagement_allowunencryptedtraffic_client_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Remote management Disallowdigestauthentication</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_remotemanagement_disallowdigestauthentication | Raw choice: device_vendor_msft_policy_config_remotemanagement_disallowdigestauthentication_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Remote management Allowbasicauthentication Service</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_remotemanagement_allowbasicauthentication_service | Raw choice: device_vendor_msft_policy_config_remotemanagement_allowbasicauthentication_service_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Remote management Allowunencryptedtraffic Service</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_remotemanagement_allowunencryptedtraffic_service | Raw choice: device_vendor_msft_policy_config_remotemanagement_allowunencryptedtraffic_service_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Remote management Disallowstoringofrunascredentials</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_remotemanagement_disallowstoringofrunascredentials | Raw choice: device_vendor_msft_policy_config_remotemanagement_disallowstoringofrunascredentials_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Kerberos Pkinithashalgorithmconfiguration</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / Kerberos Pkinithashalgorithmsha1: Disabled / Kerberos Pkinithashalgorithmsha256: Enabled / Kerberos Pkinithashalgorit...</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_kerberos_pkinithashalgorithmconfiguration | Raw choice: device_vendor_msft_policy_config_kerberos_pkinithashalgorithmconfiguration_1 | device_vendor_msft_policy_config_kerberos_pkinithashalgorithmsha1: device_vendor_msft_policy_config_kerberos_pkinithashalgorithmsha1_0 | device_vendor_msft_policy_config_kerberos_pkinithashalgorithmsha256: device_vendor_msft_policy_config_kerberos_pkinithashalgorithmsha256_1 | device_vendor_msft_policy_config_kerberos_pkinithashalgorithmsha384: device_vendor_msft_policy_config_kerberos_pkinithashalgorithmsha384_1 | device_vendor_msft_policy_config_kerberos_pkinithashalgorithmsha512: device_vendor_msft_policy_config_kerberos_pkinithashalgorithmsha512_1</span>
+                          </div>
+                          </div>
+                        </section>
+
+                        <section class="setting-group">
+                          <div class="setting-group-header">
+                            <strong>Sign-in experience</strong>
+                            <span>4 settings</span>
+                          </div>
+                          <div class="setting-group-cards">
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Logon Blockuserfromshowingaccountdetailsonsignin</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_logon_blockuserfromshowingaccountdetailsonsignin | Raw choice: device_vendor_msft_policy_config_admx_logon_blockuserfromshowingaccountdetailsonsignin_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Windows logon Do not display network selection UI</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_windowslogon_dontdisplaynetworkselectionui | Raw choice: device_vendor_msft_policy_config_windowslogon_dontdisplaynetworkselectionui_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Logon Dontenumerateconnectedusers</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_logon_dontenumerateconnectedusers | Raw choice: device_vendor_msft_policy_config_admx_logon_dontenumerateconnectedusers_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Windows logon Enumeratelocalusersondomainjoinedcomputers</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_windowslogon_enumeratelocalusersondomainjoinedcomputers | Raw choice: device_vendor_msft_policy_config_windowslogon_enumeratelocalusersondomainjoinedcomputers_0</span>
+                          </div>
+                          </div>
+                        </section>
+
+                        <section class="setting-group">
+                          <div class="setting-group-header">
+                            <strong>System and device hardening</strong>
+                            <span>14 settings</span>
+                          </div>
+                          <div class="setting-group-cards">
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Device installation Preventdevicemetadatafromnetwork</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_deviceinstallation_preventdevicemetadatafromnetwork | Raw choice: device_vendor_msft_policy_config_deviceinstallation_preventdevicemetadatafromnetwork_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>System Bootstartdriverinitialization</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / System Bootstartdriverinitialization Selectdriverloadpolicy: Option 3</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_system_bootstartdriverinitialization | Raw choice: device_vendor_msft_policy_config_system_bootstartdriverinitialization_1 | device_vendor_msft_policy_config_system_bootstartdriverinitialization_selectdriverloadpolicy: device_vendor_msft_policy_config_system_bootstartdriverinitialization_selectdriverloadpolicy_3</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Autoplay Disallowautoplayfornonvolumedevices</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_autoplay_disallowautoplayfornonvolumedevices | Raw choice: device_vendor_msft_policy_config_autoplay_disallowautoplayfornonvolumedevices_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Autoplay Setdefaultautorunbehavior</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / Autoplay Setdefaultautorunbehavior Noautorun Dropdown: Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_autoplay_setdefaultautorunbehavior | Raw choice: device_vendor_msft_policy_config_autoplay_setdefaultautorunbehavior_1 | device_vendor_msft_policy_config_autoplay_setdefaultautorunbehavior_noautorun_dropdown: device_vendor_msft_policy_config_autoplay_setdefaultautorunbehavior_noautorun_dropdown_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Autoplay Turnoffautoplay</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / Autoplay Turnoffautoplay Autorun Box: Option 255</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_autoplay_turnoffautoplay | Raw choice: device_vendor_msft_policy_config_autoplay_turnoffautoplay_1 | device_vendor_msft_policy_config_autoplay_turnoffautoplay_autorun_box: device_vendor_msft_policy_config_autoplay_turnoffautoplay_autorun_box_255</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Data protection Allowdirectmemoryaccess</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_dataprotection_allowdirectmemoryaccess | Raw choice: device_vendor_msft_policy_config_dataprotection_allowdirectmemoryaccess_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Security Allowaddprovisioningpackage</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_security_allowaddprovisioningpackage | Raw choice: device_vendor_msft_policy_config_security_allowaddprovisioningpackage_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Security Allowremoveprovisioningpackage</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_security_allowremoveprovisioningpackage | Raw choice: device_vendor_msft_policy_config_security_allowremoveprovisioningpackage_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Security Requireretrievehealthcertificateonboot</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_security_requireretrievehealthcertificateonboot | Raw choice: device_vendor_msft_policy_config_security_requireretrievehealthcertificateonboot_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>System services Configurexboxaccessorymanagementservicestartupmode</strong>
+                              </div>
+                              <div class="setting-value val-numeric">Option 4</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_systemservices_configurexboxaccessorymanagementservicestartupmode | Raw choice: device_vendor_msft_policy_config_systemservices_configurexboxaccessorymanagementservicestartupmode_4</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>System services Configurexboxliveauthmanagerservicestartupmode</strong>
+                              </div>
+                              <div class="setting-value val-numeric">Option 4</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_systemservices_configurexboxliveauthmanagerservicestartupmode | Raw choice: device_vendor_msft_policy_config_systemservices_configurexboxliveauthmanagerservicestartupmode_4</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>System services Configurexboxlivegamesaveservicestartupmode</strong>
+                              </div>
+                              <div class="setting-value val-numeric">Option 4</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_systemservices_configurexboxlivegamesaveservicestartupmode | Raw choice: device_vendor_msft_policy_config_systemservices_configurexboxlivegamesaveservicestartupmode_4</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>System services Configurexboxlivenetworkingservicestartupmode</strong>
+                              </div>
+                              <div class="setting-value val-numeric">Option 4</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_systemservices_configurexboxlivenetworkingservicestartupmode | Raw choice: device_vendor_msft_policy_config_systemservices_configurexboxlivenetworkingservicestartupmode_4</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Task Scheduler Enablexboxgamesavetask</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_taskscheduler_enablexboxgamesavetask | Raw choice: device_vendor_msft_policy_config_taskscheduler_enablexboxgamesavetask_0</span>
+                          </div>
+                          </div>
+                        </section>
+
+                        <section class="setting-group">
+                          <div class="setting-group-header">
+                            <strong>Policy and management controls</strong>
+                            <span>1 settings</span>
+                          </div>
+                          <div class="setting-group-cards">
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Grouppolicy Enablecdp</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_grouppolicy_enablecdp | Raw choice: device_vendor_msft_policy_config_admx_grouppolicy_enablecdp_0</span>
+                          </div>
+                          </div>
+                        </section>
+
+                        <section class="setting-group">
+                          <div class="setting-group-header">
+                            <strong>User experience and app surface</strong>
+                            <span>15 settings</span>
+                          </div>
+                          <div class="setting-group-cards">
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>File Explorer Turnoffdataexecutionpreventionforexplorer</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_fileexplorer_turnoffdataexecutionpreventionforexplorer | Raw choice: device_vendor_msft_policy_config_fileexplorer_turnoffdataexecutionpreventionforexplorer_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>File Explorer Turnoffheapterminationoncorruption</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_fileexplorer_turnoffheapterminationoncorruption | Raw choice: device_vendor_msft_policy_config_fileexplorer_turnoffheapterminationoncorruption_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Internet Explorer Disableinternetexplorerapp V2</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / Internet Explorer Disableinternetexplorerapp V2 Notifydisableieoptions: Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_internetexplorer_disableinternetexplorerapp_v2 | Raw choice: device_vendor_msft_policy_config_internetexplorer_disableinternetexplorerapp_v2_1 | device_vendor_msft_policy_config_internetexplorer_disableinternetexplorerapp_v2_notifydisableieoptions: device_vendor_msft_policy_config_internetexplorer_disableinternetexplorerapp_v2_notifydisableieoptions_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Internet Explorer Disableenclosuredownloading</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_internetexplorer_disableenclosuredownloading | Raw choice: device_vendor_msft_policy_config_internetexplorer_disableenclosuredownloading_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Windows PowerShell Turnonpowershellscriptblocklogging</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / Windows PowerShell Turnonpowershellscriptblocklogging Enablescriptblockinvocationlogging: Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_windowspowershell_turnonpowershellscriptblocklogging | Raw choice: device_vendor_msft_policy_config_windowspowershell_turnonpowershellscriptblocklogging_1 | device_vendor_msft_policy_config_windowspowershell_turnonpowershellscriptblocklogging_enablescriptblockinvocationlogging: device_vendor_msft_policy_config_windowspowershell_turnonpowershellscriptblocklogging_enablescriptblockinvocationlogging_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Experience Allowcortana</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_experience_allowcortana | Raw choice: device_vendor_msft_policy_config_experience_allowcortana_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Experience Allowmanualmdmunenrollment</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_experience_allowmanualmdmunenrollment | Raw choice: device_vendor_msft_policy_config_experience_allowmanualmdmunenrollment_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Games Allowadvancedgamingservices</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_games_allowadvancedgamingservices | Raw choice: device_vendor_msft_policy_config_games_allowadvancedgamingservices_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Privacy Allowinputpersonalization</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_privacy_allowinputpersonalization | Raw choice: device_vendor_msft_policy_config_privacy_allowinputpersonalization_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Privacy Disableprivacyexperience</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_privacy_disableprivacyexperience | Raw choice: device_vendor_msft_policy_config_privacy_disableprivacyexperience_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Settings Pagevisibilitylist</strong>
+                              </div>
+                              <div class="setting-value val-complex">hide:gaming-gamebar;gaming-gamedvr;gaming-broadcasting;gaming-gamemode;gaming-xboxnetworking</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_settings_pagevisibilitylist | Raw value: hide:gaming-gamebar;gaming-gamedvr;gaming-broadcasting;gaming-gamemode;gaming-xboxnetworking</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>SmartScreen Enablesmartscreeninshell</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_smartscreen_enablesmartscreeninshell | Raw choice: device_vendor_msft_policy_config_smartscreen_enablesmartscreeninshell_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>SmartScreen Preventoverrideforfilesinshell</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_smartscreen_preventoverrideforfilesinshell | Raw choice: device_vendor_msft_policy_config_smartscreen_preventoverrideforfilesinshell_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Sudo Enablesudo</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_sudo_enablesudo | Raw choice: device_vendor_msft_policy_config_sudo_enablesudo_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Windows Ink Workspace Allowwindowsinkworkspace</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_windowsinkworkspace_allowwindowsinkworkspace | Raw choice: device_vendor_msft_policy_config_windowsinkworkspace_allowwindowsinkworkspace_1</span>
+                          </div>
+                          </div>
+                        </section>
+
+                        <section class="setting-group">
+                          <div class="setting-group-header">
+                            <strong>Admx</strong>
+                            <span>11 settings</span>
+                          </div>
+                          <div class="setting-group-cards">
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Mss legacy Mss Safedllsearchmode</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_mss-legacy_pol_mss_safedllsearchmode | Raw choice: device_vendor_msft_policy_config_admx_mss-legacy_pol_mss_safedllsearchmode_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Mss legacy Mss Screensavergraceperiod</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / Mss legacy Mss Screensavergraceperiod Screensavergraceperiod: 0</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_mss-legacy_pol_mss_screensavergraceperiod | Raw choice: device_vendor_msft_policy_config_admx_mss-legacy_pol_mss_screensavergraceperiod_1 | device_vendor_msft_policy_config_admx_mss-legacy_pol_mss_screensavergraceperiod_screensavergraceperiod: 0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Mss legacy Mss Warninglevel</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / Mss legacy Mss Warninglevel Warninglevel: Option 90</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_mss-legacy_pol_mss_warninglevel | Raw choice: device_vendor_msft_policy_config_admx_mss-legacy_pol_mss_warninglevel_1 | device_vendor_msft_policy_config_admx_mss-legacy_pol_mss_warninglevel_warninglevel: device_vendor_msft_policy_config_admx_mss-legacy_pol_mss_warninglevel_warninglevel_90</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Dnsclient Turn Off Multicast</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_dnsclient_turn_off_multicast | Raw choice: device_vendor_msft_policy_config_admx_dnsclient_turn_off_multicast_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Network connections Nc Showsharedaccessui</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_networkconnections_nc_showsharedaccessui | Raw choice: device_vendor_msft_policy_config_admx_networkconnections_nc_showsharedaccessui_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Network connections Nc Stddomainusersetlocation</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_networkconnections_nc_stddomainusersetlocation | Raw choice: device_vendor_msft_policy_config_admx_networkconnections_nc_stddomainusersetlocation_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>WCM WCM Minimizeconnections</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / WCM WCM Minimizeconnections WCM Minimizeconnections Options: Option 3</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_wcm_wcm_minimizeconnections | Raw choice: device_vendor_msft_policy_config_admx_wcm_wcm_minimizeconnections_1 | device_vendor_msft_policy_config_admx_wcm_wcm_minimizeconnections_wcm_minimizeconnections_options: device_vendor_msft_policy_config_admx_wcm_wcm_minimizeconnections_wcm_minimizeconnections_options_3</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Windowsexplorer Enablesmartscreen</strong>
+                              </div>
+                              <div class="setting-value val-complex">Enabled / Windowsexplorer Enablesmartscreen Enablesmartscreendropdown: Windowsexplorer Enablesmartscreen Enablesmartscreendropd...</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_windowsexplorer_enablesmartscreen | Raw choice: device_vendor_msft_policy_config_admx_windowsexplorer_enablesmartscreen_1 | device_vendor_msft_policy_config_admx_windowsexplorer_enablesmartscreen_enablesmartscreendropdown: device_vendor_msft_policy_config_admx_windowsexplorer_enablesmartscreen_enablesmartscreendropdown_block</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Windowsexplorer Shellprotocolprotectedmodetitle 2</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_windowsexplorer_shellprotocolprotectedmodetitle_2 | Raw choice: device_vendor_msft_policy_config_admx_windowsexplorer_shellprotocolprotectedmodetitle_2_0</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Sharing Disablehomegroup</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_sharing_disablehomegroup | Raw choice: device_vendor_msft_policy_config_admx_sharing_disablehomegroup_1</span>
+                          </div>
+
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Pushtoinstall Disablepushtoinstall</strong>
+                              </div>
+                              <div class="setting-value val-enabled">Enabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_admx_pushtoinstall_disablepushtoinstall | Raw choice: device_vendor_msft_policy_config_admx_pushtoinstall_disablepushtoinstall_1</span>
+                          </div>
+                          </div>
+                        </section>
+
+                        <section class="setting-group">
+                          <div class="setting-group-header">
+                            <strong>Error reporting</strong>
+                            <span>1 settings</span>
+                          </div>
+                          <div class="setting-group-cards">
+                          <div class="settings-card">
+                            <div class="setting-top">
+                              <div>
+                                <strong>Error reporting Disablewindowserrorreporting</strong>
+                              </div>
+                              <div class="setting-value val-disabled">Disabled</div>
+                            </div>
+                            <span class="setting-tooltip">Definition ID: device_vendor_msft_policy_config_errorreporting_disablewindowserrorreporting | Raw choice: device_vendor_msft_policy_config_errorreporting_disablewindowserrorreporting_0</span>
+                          </div>
+                          </div>
+                        </section>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+            </div>
+
+            <div class="footer-note">
+              <span>204 items loaded</span>
+              <span>204 policies</span>
+            </div>
+          </section>
+
+          <section id="health" class="workspace">
+            <div class="section-toolbar">
+              <div class="section-title">
+                <strong>Device Health Scripts studio</strong>
+                <span>Operational health, code, and actions in one cleaner dashboard flow.</span>
+              </div>
+              <div class="toolbar-right">
+                <span class="chip">Errors only</span>
+                <span class="chip">Remediation enabled</span>
+                <button class="secondary-btn">Deploy on demand</button>
+                <button class="primary-btn">Export run summary</button>
+              </div>
+            </div>
+
+            <div class="metrics">
+              <div class="metric-card">
+                <small>Scripts</small>
+                <strong>42</strong>
+                <span>Filterable by cadence and platform.</span>
+              </div>
+              <div class="metric-card">
+                <small>Detected</small>
+                <strong style="color: var(--warning);">137</strong>
+                <span>Highlighted for immediate follow-up.</span>
+              </div>
+              <div class="metric-card">
+                <small>Remediated</small>
+                <strong style="color: var(--success);">1,046</strong>
+                <span>Operational success stays visible.</span>
+              </div>
+              <div class="metric-card">
+                <small>Errors</small>
+                <strong style="color: var(--error);">19</strong>
+                <span>Triage-friendly by default.</span>
+              </div>
+            </div>
+
+            <div class="content-2col">
+              <div class="stack">
+                <div class="panel">
+                  <div class="panel-header">
+                    <strong>Script overview</strong>
+                    <span>Metadata + health table</span>
+                  </div>
+                  <div class="panel-body">
+                    <div class="meta-grid">
+                      <div class="meta-card">
+                        <small>Script</small>
+                        <span>Detect local admin drift and repair membership</span>
+                      </div>
+                      <div class="meta-card">
+                        <small>Publisher</small>
+                        <span>Endpoint Engineering</span>
+                      </div>
+                      <div class="meta-card">
+                        <small>Run cadence</small>
+                        <span>Every 4 hours / userless / 64-bit</span>
+                      </div>
+                      <div class="meta-card">
+                        <small>Signature enforcement</small>
+                        <span>Enabled</span>
+                      </div>
+                    </div>
+
+                    <div class="health-grid" style="margin-top: 16px;">
+                      <div class="panel" style="box-shadow: none; border-radius: 14px;">
+                        <div class="panel-header">
+                          <strong>Device run states</strong>
+                          <span>Operator-first view</span>
+                        </div>
+                        <div class="panel-body" style="padding-top: 8px;">
+                          <table>
+                            <thead>
+                              <tr>
+                                <th>Device</th>
+                                <th>Detection</th>
+                                <th>Remediation</th>
+                                <th>Updated</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <tr>
+                                <td>WKS-T0-004</td>
+                                <td><span class="badge warning">Issue detected</span></td>
+                                <td><span class="badge success">Remediated</span></td>
+                                <td>13 min ago</td>
+                              </tr>
+                              <tr>
+                                <td>WKS-T0-009</td>
+                                <td><span class="badge error">Error</span></td>
+                                <td><span class="badge error">Retry queued</span></td>
+                                <td>22 min ago</td>
+                              </tr>
+                              <tr>
+                                <td>LAP-HR-241</td>
+                                <td><span class="badge success">No issue</span></td>
+                                <td><span class="badge success">Not needed</span></td>
+                                <td>41 min ago</td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+
+                      <div class="stack">
+                        <div class="side-note" style="margin-bottom: 0;">
+                          <strong>Assignments</strong>
+                          <span>3 active groups / 1 pilot / 1 detection-only</span>
+                        </div>
+                        <div class="side-note" style="margin-bottom: 0;">
+                          <strong>Why this layout works</strong>
+                          <span>Run states are elevated above the fold instead of being buried under metadata.</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="code-grid">
+                  <div class="code-card">
+                    <div class="head">
+                      <strong>Detection script</strong>
+                      <span class="code-caption">Readable code pane</span>
+                    </div>
+                    <pre># Detect unexpected local administrators
+$allowed = @("Administrator", "Tier0-Workstation-Admins")
+$current = Get-LocalGroupMember -Group "Administrators"
+$drift = $current | Where-Object { $_.Name -notin $allowed }
+
+if ($drift.Count -gt 0) {
+  Write-Output "Drift detected"
+  exit 1
+}
+
+Write-Output "No issue detected"
+exit 0</pre>
+                  </div>
+                  <div class="code-card">
+                    <div class="head">
+                      <strong>Remediation script</strong>
+                      <span class="code-caption">Side-by-side review</span>
+                    </div>
+                    <pre># Remove unexpected local admins
+$allowed = @("Administrator", "Tier0-Workstation-Admins")
+$members = Get-LocalGroupMember -Group "Administrators"
+$remove = $members | Where-Object { $_.Name -notin $allowed }
+
+foreach ($entry in $remove) {
+  Remove-LocalGroupMember -Group "Administrators" -Member $entry.Name
+}
+
+Write-Output "Remediation complete"</pre>
+                  </div>
+                </div>
+              </div>
+
+              <div class="stack">
+                <div class="panel">
+                  <div class="panel-header">
+                    <strong>Operational side rail</strong>
+                    <span>Schedules, actions, history</span>
+                  </div>
+                  <div class="panel-body">
+                    <div class="side-note">
+                      <strong>Schedule</strong>
+                      <ul>
+                        <li>Tier 0 Workstations / every 4 hours / remediation on</li>
+                        <li>Windows Pilot Ring / every 12 hours / remediation on</li>
+                        <li>Breakglass Lab / daily / detection only</li>
+                      </ul>
+                    </div>
+                    <div class="side-note">
+                      <strong>Quick actions</strong>
+                      <ul>
+                        <li>View only failed devices</li>
+                        <li>Launch assignment report for this script</li>
+                        <li>Open previous exported artifact</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="footer-note">
+              <span>Goal: clean operational dashboard, not a giant detail pane with code tacked on.</span>
+              <span>Still keeps native deploy/export hooks.</span>
+            </div>
+          </section>
+
+          <section id="reports" class="workspace">
+            <div class="section-toolbar">
+              <div class="section-title">
+                <strong>Reports and dashboards</strong>
+                <span>Turn reports into a first-class analysis surface instead of a separate utility window.</span>
+              </div>
+              <div class="toolbar-right">
+                <span class="chip">Group assignments</span>
+                <span class="chip">Saved lens: Security</span>
+                <button class="secondary-btn">Save preset</button>
+                <button class="primary-btn">Run report</button>
+              </div>
+            </div>
+
+            <div class="content-reports">
+              <div class="stack">
+                <div class="panel">
+                  <div class="panel-header">
+                    <strong>Modes</strong>
+                    <span>Persistent, not modal</span>
+                  </div>
+                  <div class="panel-body">
+                    <div class="mode-list">
+                      <div class="mode-card active">
+                        <strong>Group assignments</strong>
+                        <span>Inspect direct and inherited coverage with fast export paths.</span>
+                      </div>
+                      <div class="mode-card">
+                        <strong>Compare groups</strong>
+                        <span>Shared and unique coverage, conflicts, and exclusions.</span>
+                      </div>
+                      <div class="mode-card">
+                        <strong>Failed assignments</strong>
+                        <span>Error-focused triage.</span>
+                      </div>
+                      <div class="mode-card">
+                        <strong>All policies overview</strong>
+                        <span>Portfolio and targeting health.</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="panel">
+                  <div class="panel-header">
+                    <strong>Inputs</strong>
+                    <span>Contextual and reusable</span>
+                  </div>
+                  <div class="panel-body">
+                    <div class="list">
+                      <div class="list-card active">
+                        <strong>Selected group</strong>
+                        <span>Tier0-Admin-Workstations / 1,842 members / dynamic</span>
+                      </div>
+                      <div class="list-card">
+                        <strong>Scope options</strong>
+                        <span>Include inherited / highlight exclusions / show empty targets</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="stack">
+                <div class="panel">
+                  <div class="panel-header">
+                    <strong>Device inventory snapshot</strong>
+                    <span>Real export counts from the tagged inventory CSV</span>
+                  </div>
+                  <div class="panel-body">
+                    <div class="mini-metrics">
+                      <div class="mini-metric">
+                        <strong>53</strong>
+                        <span>Devices in export</span>
+                      </div>
+                      <div class="mini-metric">
+                        <strong>18</strong>
+                        <span>Compliant devices</span>
+                      </div>
+                      <div class="mini-metric">
+                        <strong>21</strong>
+                        <span>Noncompliant devices</span>
+                      </div>
+                      <div class="mini-metric">
+                        <strong>14</strong>
+                        <span>Not evaluated</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="panel">
+                  <div class="panel-header">
+                    <strong>Compliance mix</strong>
+                    <span>Derived from the same device inventory export</span>
+                  </div>
+                  <div class="panel-body">
+                    <div class="chart-list">
+                      <div class="bar-row">
+                        <label><span>Noncompliant</span><span>21</span></label>
+                        <div class="bar"><span style="width: 40%; background: var(--warning);"></span></div>
+                      </div>
+                      <div class="bar-row">
+                        <label><span>Compliant</span><span>18</span></label>
+                        <div class="bar"><span style="width: 34%; background: var(--success);"></span></div>
+                      </div>
+                      <div class="bar-row">
+                        <label><span>Not evaluated</span><span>14</span></label>
+                        <div class="bar"><span style="width: 26%; background: var(--text-muted);"></span></div>
+                      </div>
+                      <div class="bar-row">
+                        <label><span>Corporate ownership</span><span>38</span></label>
+                        <div class="bar"><span style="width: 72%;"></span></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="panel">
+                  <div class="panel-header">
+                    <strong>Inventory evidence table</strong>
+                    <span>Sample rows from `DevicesWithInventory...csv`</span>
+                  </div>
+                  <div class="panel-body">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Device</th>
+                          <th>Compliance</th>
+                          <th>Primary user</th>
+                          <th>Last check-in</th>
+                          <th>Model</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td>Gell-VM-48633452</td>
+                          <td><span class="badge success">Compliant</span></td>
+                          <td>Adam.Gell@CDWWorkspaceLabs.onmicrosoft.com</td>
+                          <td>2026-03-13 19:56</td>
+                          <td>Virtual Machine</td>
+                        </tr>
+                        <tr>
+                          <td>SNAKES</td>
+                          <td><span class="badge warning">Noncompliant</span></td>
+                          <td>NeeReja.Gibson@CDWWorkspaceLabs.onmicrosoft.com</td>
+                          <td>2025-10-02 04:44</td>
+                          <td>Virtual Machine</td>
+                        </tr>
+                        <tr>
+                          <td>AUTOPILOT-633</td>
+                          <td><span class="badge success">Compliant</span></td>
+                          <td>NeeReja.Gibson@CDWWorkspaceLabs.onmicrosoft.com</td>
+                          <td>2026-03-13 01:42</td>
+                          <td>Surface Go 4</td>
+                        </tr>
+                        <tr>
+                          <td>DESKTOP-DC1S44C</td>
+                          <td><span class="badge warning">Noncompliant</span></td>
+                          <td>Adam.Gell@CDWWorkspaceLabs.onmicrosoft.com</td>
+                          <td>2026-02-11 01:43</td>
+                          <td>Virtual Machine</td>
+                        </tr>
+                        <tr>
+                          <td>CPC-AdamG-TLKWB</td>
+                          <td><span class="badge success">Compliant</span></td>
+                          <td>Adam.Gell@CDWWorkspaceLabs.onmicrosoft.com</td>
+                          <td>2026-03-13 11:18</td>
+                          <td>Cloud PC Enterprise 4vCPU/16GB/128GB</td>
+                        </tr>
+                        <tr>
+                          <td>NeeReja.Gibson_Windows_3/11/2026_4:56 PM</td>
+                          <td><span class="badge error">Not evaluated</span></td>
+                          <td>NeeReja.Gibson@CDWWorkspaceLabs.onmicrosoft.com</td>
+                          <td>0001-01-01 00:00</td>
+                          <td>Unspecified</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+
+              <div class="stack">
+                <div class="panel">
+                  <div class="panel-header">
+                    <strong>Export tray</strong>
+                    <span>Native shell hooks</span>
+                  </div>
+                  <div class="panel-body">
+                    <div class="insight-card">
+                      <strong>HTML report</strong>
+                      <span>Readable narrative summary plus evidence table and active filters.</span>
+                    </div>
+                    <div class="insight-card" style="margin-top: 10px;">
+                      <strong>CSV export</strong>
+                      <span>Flat operational output for downstream analysis.</span>
+                    </div>
+                    <div class="insight-card" style="margin-top: 10px;">
+                      <strong>Open in category</strong>
+                      <span>Jump from a row directly into Settings Catalog or Device Health Scripts.</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="footer-note">
+              <span>Goal: report UX should feel like a clean dashboard surface, not a utility popup.</span>
+              <span>Closer to modern React admin UI systems.</span>
+            </div>
+          </section>
+        </main>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    const buttons = document.querySelectorAll('.switcher button');
+    const screens = document.querySelectorAll('.workspace');
+
+    buttons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const target = button.dataset.target;
+        buttons.forEach((item) => item.classList.toggle('active', item === button));
+        screens.forEach((screen) => screen.classList.toggle('active', screen.id === target));
+      });
+    });
+
+    function showDetail() {
+      document.getElementById('settingsColumns').classList.add('detail-active');
+      window.scrollTo(0, 0);
+    }
+
+    function showList() {
+      document.getElementById('settingsColumns').classList.remove('detail-active');
+      window.scrollTo(0, 0);
+    }
+
+    function toggleMeta() {
+      const adv = document.getElementById('metaAdvanced');
+      const btn = document.getElementById('metaToggle');
+      adv.classList.toggle('open');
+      btn.classList.toggle('open');
+      btn.lastChild.textContent = adv.classList.contains('open') ? ' Hide advanced details' : ' Show advanced details';
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds an HTML mockup for the new React web shell UI, replacing the Avalonia desktop frontend
- Settings Catalog view with list/detail navigation pattern (full-width table → drill-in detail view)
- Inline stat pills, color-coded setting value badges, and collapsible meta grid
- Dark theme matching Intune Commander branding

## Test plan
- [ ] Open `webview-first-slice-mockups.html` in a browser
- [ ] Verify policy list table renders with View buttons per row
- [ ] Click View → confirm detail view loads with back button, meta cards, and color-coded settings
- [ ] Click "Show advanced details" toggle → verify it expands/collapses
- [ ] Click "Back to list" → confirm return to full policy table

🤖 Generated with [Claude Code](https://claude.com/claude-code)