### PR TITLE
Release v0.4.5: Switch to React/WPF UI

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,6 +34,12 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
+      - name: Setup Node.js
+        if: steps.check-solution.outputs.exists == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Restore dependencies
         if: steps.check-solution.outputs.exists == 'true'
         run: dotnet restore Intune.Commander.sln
@@ -42,26 +48,30 @@ jobs:
         if: steps.check-solution.outputs.exists == 'true'
         run: dotnet build Intune.Commander.sln --configuration Release --no-restore
 
+      - name: Build React frontend
+        if: steps.check-solution.outputs.exists == 'true'
+        working-directory: intune-commander-react
+        run: |
+          npm ci
+          npm run build
+
       - name: Publish Windows x64 executable
         if: steps.check-solution.outputs.exists == 'true'
-        env:
-          SYNCFUSION_LICENSE_KEY: ${{ secrets.SYNCFUSION_LICENSE_KEY }}
         run: |
-          dotnet publish src/Intune.Commander.Desktop/Intune.Commander.Desktop.csproj `
+          dotnet publish src/Intune.Commander.DesktopReact/Intune.Commander.DesktopReact.csproj `
             --configuration Release `
             --runtime win-x64 `
             --self-contained true `
             --output ./publish `
             -p:PublishSingleFile=true `
-            -p:IncludeNativeLibrariesForSelfExtract=true `
-            -p:SyncfusionLicenseKey="$env:SYNCFUSION_LICENSE_KEY"
+            -p:IncludeNativeLibrariesForSelfExtract=true
 
       - name: Upload artifact
         if: steps.check-solution.outputs.exists == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: Intune.Commander-win-x64
-          path: ./publish/Intune.Commander.Desktop.exe
+          path: ./publish/IntuneCommander.exe
           retention-days: 30
 
   publish-cli:

--- a/.github/workflows/codesign.yml
+++ b/.github/workflows/codesign.yml
@@ -15,9 +15,11 @@ permissions:
   contents: write
 
 env:
-  PROJECT: src/Intune.Commander.Desktop/Intune.Commander.Desktop.csproj
-  PUBLISH_DIR: src/Intune.Commander.Desktop/bin/Release/net10.0/win-x64/publish
+  PROJECT: src/Intune.Commander.DesktopReact/Intune.Commander.DesktopReact.csproj
+  PUBLISH_DIR: src/Intune.Commander.DesktopReact/bin/Release/net10.0-windows/win-x64/publish
+  REACT_DIR: intune-commander-react
   DOTNET_VERSION: '10.0.x'
+  NODE_VERSION: '20'
   GH_REPO: adamgell/IntuneCommander
 
 jobs:
@@ -35,6 +37,11 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Determine version
         id: version
@@ -63,12 +70,16 @@ jobs:
           git tag -a ${{ steps.version.outputs.tag }} -m "Release ${{ steps.version.outputs.tag }}"
           git push origin ${{ steps.version.outputs.tag }}
 
+      - name: Build React frontend
+        working-directory: ${{ env.REACT_DIR }}
+        run: |
+          npm ci
+          npm run build
+
       - name: Restore dependencies
         run: dotnet restore ${{ env.PROJECT }} -r win-x64
 
       - name: Publish
-        env:
-          SYNCFUSION_LICENSE_KEY: ${{ secrets.SYNCFUSION_LICENSE_KEY }}
         run: >
           dotnet publish ${{ env.PROJECT }}
           -c Release
@@ -78,18 +89,17 @@ jobs:
           -p:PublishSingleFile=true
           -p:IncludeNativeLibrariesForSelfExtract=true
           -p:Version=${{ steps.version.outputs.version }}
-          "-p:SyncfusionLicenseKey=$env:SYNCFUSION_LICENSE_KEY"
 
       - name: Verify build output
         shell: bash
         run: |
-          EXE="${{ env.PUBLISH_DIR }}/Intune.Commander.Desktop.exe"
+          EXE="${{ env.PUBLISH_DIR }}/IntuneCommander.exe"
           if [ ! -f "$EXE" ]; then
             echo "::error::Build output not found at $EXE"
             exit 1
           fi
           SIZE=$(stat -c%s "$EXE" 2>/dev/null || stat -f%z "$EXE")
-          echo "Artifact: Intune.Commander.Desktop.exe ($SIZE bytes)"
+          echo "Artifact: IntuneCommander.exe ($SIZE bytes)"
 
       - name: Sign with Trusted Signing
         uses: azure/trusted-signing-action@v0
@@ -118,7 +128,7 @@ jobs:
 
           gh release create "${{ steps.version.outputs.tag }}" \
             -R "${{ env.GH_REPO }}" \
-            "${{ env.PUBLISH_DIR }}/Intune.Commander.Desktop.exe" \
+            "${{ env.PUBLISH_DIR }}/IntuneCommander.exe" \
             --title "${{ steps.version.outputs.tag }}" \
             --generate-notes \
             $PRERELEASE_FLAG

--- a/src/Intune.Commander.Desktop/Intune.Commander.Desktop.csproj
+++ b/src/Intune.Commander.Desktop/Intune.Commander.Desktop.csproj
@@ -9,6 +9,7 @@
     <AssemblyTitle>Intune Commander</AssemblyTitle>
     <Product>Intune Commander</Product>
     <ApplicationIcon>..\..\icon.ico</ApplicationIcon>
+    <AssemblyName>IntuneCommander</AssemblyName>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>

--- a/src/Intune.Commander.DesktopReact/Intune.Commander.DesktopReact.csproj
+++ b/src/Intune.Commander.DesktopReact/Intune.Commander.DesktopReact.csproj
@@ -7,9 +7,13 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>..\..\icon.ico</ApplicationIcon>
-    <Version>0.5.0</Version>
+    <Version>0.4.5</Version>
+    <AssemblyVersion>0.4.5.0</AssemblyVersion>
+    <FileVersion>0.4.5.0</FileVersion>
+    <AssemblyTitle>Intune Commander</AssemblyTitle>
+    <Product>Intune Commander</Product>
     <RootNamespace>Intune.Commander.DesktopReact</RootNamespace>
-    <AssemblyName>Intune.Commander.DesktopReact</AssemblyName>
+    <AssemblyName>IntuneCommander</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Switch release builds from Avalonia to React + WPF (WebView2) in both `build-release.yml` and `codesign.yml`
- Rename output assembly to `IntuneCommander.exe` (was `Intune.Commander.Desktop.exe`)
- Add Node.js setup and React frontend build steps to CI pipelines
- Set DesktopReact project version to 0.4.5 with proper assembly metadata

## Test plan
- [ ] Verify `build-release.yml` CI passes and produces `IntuneCommander.exe` artifact
- [ ] Verify codesign workflow builds correctly when triggered manually
- [ ] Confirm the exe file properties show "Intune Commander" (not Avalonia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)