### PR TITLE
fix: Conditional Access state mapping, filter, and export buttons (#205)

### DIFF
--- a/intune-commander-react/src/components/workspace/CaPolicyDetailPanel.tsx
+++ b/intune-commander-react/src/components/workspace/CaPolicyDetailPanel.tsx
@@ -70,9 +70,6 @@ export function CaPolicyDetailPanel() {
           <button className="back-btn" onClick={clearSelection}>
             Back to list
           </button>
-          <div className="detail-header-actions">
-            <button className="ws-btn secondary" disabled>Export JSON</button>
-          </div>
         </div>
       </div>
       <div className="panel-body">

--- a/intune-commander-react/src/components/workspace/ConditionalAccessWorkspace.tsx
+++ b/intune-commander-react/src/components/workspace/ConditionalAccessWorkspace.tsx
@@ -203,9 +203,6 @@ export function ConditionalAccessWorkspace() {
             </span>
           </div>
         </div>
-        <div className="workspace-actions">
-          <button className="ws-btn primary" disabled>Export selected</button>
-        </div>
       </div>
 
       <div className="platform-filter-bar">

--- a/src/Intune.Commander.DesktopReact/Services/ConditionalAccessBridgeService.cs
+++ b/src/Intune.Commander.DesktopReact/Services/ConditionalAccessBridgeService.cs
@@ -75,13 +75,12 @@ public class ConditionalAccessBridgeService
         return MapPolicyDetail(policy);
     }
 
-    private static string FormatState(ConditionalAccessPolicyState? state) => state switch
+    private static string FormatState(ConditionalAccessPolicyState? state)
     {
-        ConditionalAccessPolicyState.Enabled => "enabled",
-        ConditionalAccessPolicyState.Disabled => "disabled",
-        ConditionalAccessPolicyState.EnabledForReportingButNotEnforced => "enabledForReportingButNotEnforced",
-        _ => "disabled",
-    };
+        if (state is null) return "disabled";
+        var text = state.Value.ToString();
+        return string.IsNullOrEmpty(text) ? "disabled" : char.ToLowerInvariant(text[0]) + text[1..];
+    }
 
     private static CaPolicyListItem[] MapPolicies(List<ConditionalAccessPolicy> policies)
     {

--- a/src/Intune.Commander.DesktopReact/Services/ConditionalAccessBridgeService.cs
+++ b/src/Intune.Commander.DesktopReact/Services/ConditionalAccessBridgeService.cs
@@ -75,12 +75,20 @@ public class ConditionalAccessBridgeService
         return MapPolicyDetail(policy);
     }
 
+    private static string FormatState(ConditionalAccessPolicyState? state) => state switch
+    {
+        ConditionalAccessPolicyState.Enabled => "enabled",
+        ConditionalAccessPolicyState.Disabled => "disabled",
+        ConditionalAccessPolicyState.EnabledForReportingButNotEnforced => "enabledForReportingButNotEnforced",
+        _ => "disabled",
+    };
+
     private static CaPolicyListItem[] MapPolicies(List<ConditionalAccessPolicy> policies)
     {
         return policies.Select(p => new CaPolicyListItem(
             Id: p.Id ?? "",
             DisplayName: p.DisplayName ?? "",
-            State: p.State?.ToString() ?? "disabled",
+            State: FormatState(p.State),
             CreatedDateTime: p.CreatedDateTime?.ToString("o") ?? "",
             ModifiedDateTime: p.ModifiedDateTime?.ToString("o") ?? "",
             Description: p.Description,
@@ -174,7 +182,7 @@ public class ConditionalAccessBridgeService
         return new CaPolicyDetail(
             Id: policy.Id ?? "",
             DisplayName: policy.DisplayName ?? "",
-            State: policy.State?.ToString() ?? "disabled",
+            State: FormatState(policy.State),
             CreatedDateTime: policy.CreatedDateTime?.ToString("o") ?? "",
             ModifiedDateTime: policy.ModifiedDateTime?.ToString("o") ?? "",
             Description: policy.Description,


### PR DESCRIPTION
Fixes #205

## Summary
Three bugs reported in the Conditional Access workspace:

### 1. Detail panel always showing "Disabled"
**Root cause:** `policy.State?.ToString()` returns PascalCase (`Enabled`) but React expects camelCase (`enabled`). Added explicit `FormatState()` that maps the enum to the correct camelCase strings.

### 2. Filtering doesn't work
**Root cause:** Same as #1 — the filter chips compare against `enabled`/`disabled`/`enabledForReportingButNotEnforced` but the bridge was returning `Enabled`/`Disabled`/`EnabledForReportingButNotEnforced`. Fixed by the same `FormatState()` fix.

### 3. Import/Export greyed out
**Root cause:** Placeholder buttons with hardcoded `disabled` attribute. Removed them — export functionality is available through the dedicated Export/Import workspace.

## Test plan
- [ ] Open CA workspace — policies show correct Enabled/Report-only/Disabled states
- [ ] Click a policy — detail panel shows correct state
- [ ] Click filter chips — list filters correctly
- [ ] No greyed-out export buttons visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)