### PR TITLE
chore: bump version to 0.5.0.0

### DIFF
--- a/src/Intune.Commander.Core/Intune.Commander.Core.csproj
+++ b/src/Intune.Commander.Core/Intune.Commander.Core.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.4.5</Version>
-    <AssemblyVersion>0.4.5.0</AssemblyVersion>
-    <FileVersion>0.4.5.0</FileVersion>
+    <Version>0.5.0.0</Version>
+    <AssemblyVersion>0.5.0.0</AssemblyVersion>
+    <FileVersion>0.5.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Intune.Commander.Desktop/Intune.Commander.Desktop.csproj
+++ b/src/Intune.Commander.Desktop/Intune.Commander.Desktop.csproj
@@ -3,9 +3,9 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <Version>0.4.5</Version>
-    <AssemblyVersion>0.4.5.0</AssemblyVersion>
-    <FileVersion>0.4.5.0</FileVersion>
+    <Version>0.5.0.0</Version>
+    <AssemblyVersion>0.5.0.0</AssemblyVersion>
+    <FileVersion>0.5.0.0</FileVersion>
     <AssemblyTitle>Intune Commander</AssemblyTitle>
     <Product>Intune Commander</Product>
     <ApplicationIcon>..\..\icon.ico</ApplicationIcon>

--- a/src/Intune.Commander.DesktopReact/Intune.Commander.DesktopReact.csproj
+++ b/src/Intune.Commander.DesktopReact/Intune.Commander.DesktopReact.csproj
@@ -7,9 +7,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>..\..\icon.ico</ApplicationIcon>
-    <Version>0.4.7.0</Version>
-    <AssemblyVersion>0.4.7.0</AssemblyVersion>
-    <FileVersion>0.4.7.0</FileVersion>
+    <Version>0.5.0.0</Version>
+    <AssemblyVersion>0.5.0.0</AssemblyVersion>
+    <FileVersion>0.5.0.0</FileVersion>
     <AssemblyTitle>Intune Commander</AssemblyTitle>
     <Product>Intune Commander</Product>
     <RootNamespace>Intune.Commander.DesktopReact</RootNamespace>

--- a/src/Intune.Commander.Installer/package.signed.json
+++ b/src/Intune.Commander.Installer/package.signed.json
@@ -5,7 +5,7 @@
   "outputFileName": "IntuneCommander-$.version-x64",
   "packageName": "Intune Commander",
   "publisher": "Adam Gell",
-  "version": "0.4.7.0",
+  "version": "0.5.0.0",
   "platform": "x64",
   "installDir": "%ProgramFiles%\\Intune Commander",
   "icon": "icon.ico",


### PR DESCRIPTION
## Summary
Bump all project versions to 0.5.0.0:
- `Intune.Commander.Core` (0.4.5 -> 0.5.0.0)
- `Intune.Commander.DesktopReact` (0.4.7.0 -> 0.5.0.0)
- `Intune.Commander.Desktop` (0.4.5 -> 0.5.0.0)
- `package.signed.json` (0.4.7.0 -> 0.5.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)